### PR TITLE
Adding proxy support for token_from_code and token_from_refresh methods

### DIFF
--- a/Release/include/cpprest/oauth2.h
+++ b/Release/include/cpprest/oauth2.h
@@ -446,6 +446,24 @@ public:
     /// Default: "access_token".
     /// </summary>
     void set_access_token_key(utility::string_t access_token_key) { m_access_token_key = std::move(access_token_key); }
+	
+	/// <summary>
+	/// Get the web proxy object
+	/// </summary>
+	/// <returns>A reference to the web proxy object.</returns>
+	const web_proxy& proxy() const
+	{
+		return m_proxy;
+	}
+
+	/// <summary>
+	/// Set the web proxy object that will be used by token_from_code and token_from_refresh
+	/// </summary>
+	/// <param name="proxy">A reference to the web proxy object.</param>
+	void set_proxy(const web_proxy& proxy)
+	{
+		m_proxy = proxy;
+	}
 
 private:
     friend class web::http::client::http_client_config;
@@ -482,6 +500,8 @@ private:
     utility::string_t m_redirect_uri;
     utility::string_t m_scope;
     utility::string_t m_state;
+
+	web::web_proxy m_proxy;
 
     bool m_implicit_grant;
     bool m_bearer_auth;

--- a/Release/src/http/oauth/oauth2.cpp
+++ b/Release/src/http/oauth/oauth2.cpp
@@ -26,6 +26,7 @@
 #include "stdafx.h"
 
 using web::http::client::http_client;
+using web::http::client::http_client_config;
 using web::http::oauth2::details::oauth2_strings;
 using web::http::details::mime_types;
 using utility::conversions::to_utf8string;
@@ -134,7 +135,11 @@ pplx::task<void> oauth2_config::_request_token(uri_builder& request_body_ub)
     }
     request.set_body(request_body_ub.query(), mime_types::application_x_www_form_urlencoded);
 
-    http_client token_client(token_endpoint());
+	// configure proxy
+	http_client_config config;
+	config.set_proxy(m_proxy);
+
+    http_client token_client(token_endpoint(), config);
 
     return token_client.request(request)
     .then([](http_response resp)


### PR DESCRIPTION
Hi, 

I noticed that the token_from_code we are using in our project fails in an environment requiring proxy. The fundamental reason for this is that token_from_code under the hood instantiates a plain http_client without passing any configuration to it. 

I was considering several designs how to solve this, but for simplicity I settled down on the idea of setting the proxy directly on the Oauth2 object.

Let me know if you have a different design in mind - in general I felt that the OAuth2 config is somewhat detached from the encapsulating HTTP config object. For example, if the OAuth2 config object knew about the parent HTTP config object it would be able to pull the proxy (and other things if needed) from the parent. I was just not sure about the design intent here and didn't want to propose a bigger structural change.

Regards,
Gergely
