### PR TITLE
Add unsolicited pong support

### DIFF
--- a/Release/include/cpprest/ws_msg.h
+++ b/Release/include/cpprest/ws_msg.h
@@ -73,6 +73,15 @@ class websocket_outgoing_message
 {
 public:
 
+	/// <summary>
+	/// Sets a the outgoing message to be an unsolicited pong message.
+	/// This is useful when the client side wants to check whether the server is alive.
+	/// </summary>
+	void set_pong_message()
+	{
+		this->set_message_pong();
+	}
+
     /// <summary>
     /// Sets a UTF-8 message as the message body.
     /// </summary>
@@ -151,6 +160,14 @@ private:
     }
 
     const pplx::task_completion_event<void> & body_sent() const { return m_body_sent; }
+
+	void set_message_pong()
+	{
+		concurrency::streams::container_buffer<std::string> buffer("");
+		m_msg_type = websocket_message_type::pong;
+		m_length = static_cast<size_t>(buffer.size());
+		m_body = buffer;
+	}
 
     void set_message(const concurrency::streams::container_buffer<std::string> &buffer)
     {


### PR DESCRIPTION
Hi,

I added unsolicited pong support to Casablanca (see https://tools.ietf.org/html/rfc6455#section-5.5.3). This is useful for cases when the client wants to check whether the websocket connection is still up and running. For example, if I unplug my network cable, without this change, Casablanca simply does not notice that the Websocket connection is down, the close handler won't get invoked etc. 

With these changes, the client can send (periodically or when certain events happen, e.g. network change events) an unsolicited pong request which has no effect on a healthy websocket connection, but will help Casablanca/WebSocket++ detect that the connection has been lost. With these changes, if I unplug my network cable and if I send a pong message after that, Casablanca correctly invokes the websocket close handler within a few seconds.

Regards,
Gergely 

