### PR TITLE
Initial attempt at win32 http_listener response refactor

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -34,3 +34,6 @@ Cisco Systems
 Gergely Lukacsy (glukacsy)
 
 thomasschaub
+
+Trimble
+Tim Boundy (gigaplex)

--- a/Release/include/cpprest/details/http_server_httpsys.h
+++ b/Release/include/cpprest/details/http_server_httpsys.h
@@ -99,8 +99,13 @@ struct windows_request_context : http::details::_http_server_context
     // Dispatch request to the provided http_listener.
     void dispatch_request_to_listener(_In_ web::http::experimental::listener::details::http_listener_impl *pListener);
 
-    // Initialise the response task callbacks
-    void do_response(bool bad_request);
+    enum ShouldWaitForBody
+    {
+        WaitForBody,
+        DontWaitForBody
+    };
+    // Initialise the response task callbacks. If the body has been requested, we should wait for it to avoid race conditions.
+    void init_response_callbacks(ShouldWaitForBody shouldWait);
 
     // Read in a portion of the request body.
     void read_request_body_chunk();

--- a/Release/include/cpprest/details/http_server_httpsys.h
+++ b/Release/include/cpprest/details/http_server_httpsys.h
@@ -99,6 +99,9 @@ struct windows_request_context : http::details::_http_server_context
     // Dispatch request to the provided http_listener.
     void dispatch_request_to_listener(_In_ web::http::experimental::listener::details::http_listener_impl *pListener);
 
+    // Initialise the response task callbacks
+    void do_response(bool bad_request);
+
     // Read in a portion of the request body.
     void read_request_body_chunk();
 

--- a/Release/src/http/listener/http_listener_msg.cpp
+++ b/Release/src/http/listener/http_listener_msg.cpp
@@ -47,7 +47,7 @@ pplx::task<void> details::_http_request::_reply_impl(http_response response)
     {
         // Add a task-based continuation so no exceptions thrown from the task go 'unobserved'.
         response._set_server_context(std::move(m_server_context));
-        response_completed = experimental::details::http_server_api::server_api()->respond(response);
+        response_completed = server_api->respond(response);
         response_completed.then([](pplx::task<void> t)
         {
             try { t.wait(); } catch(...) {}

--- a/Release/src/http/listener/http_server_httpsys.cpp
+++ b/Release/src/http/listener/http_server_httpsys.cpp
@@ -690,7 +690,7 @@ void windows_request_context::dispatch_request_to_listener(_In_ web::http::exper
 void windows_request_context::init_response_callbacks(ShouldWaitForBody shouldWait)
 {
     // Use a proxy event so we're not causing a circular reference between the http_request and the response task
-	pplx::task_completion_event<void> proxy_content_ready;
+    pplx::task_completion_event<void> proxy_content_ready;
 
     auto content_ready_task = m_msg.content_ready();
     auto get_response_task = m_msg.get_response();

--- a/Release/src/http/listener/http_server_httpsys.cpp
+++ b/Release/src/http/listener/http_server_httpsys.cpp
@@ -706,7 +706,7 @@ void windows_request_context::init_response_callbacks(ShouldWaitForBody shouldWa
         catch (...)
         {
             // Copy the request reference in case it's the last
-			http_request request = m_msg;
+            http_request request = m_msg;
             m_msg = http_request();
             proxy_content_ready.set_exception(std::current_exception());
             cancel_request(std::current_exception());

--- a/Release/src/http/listener/http_server_httpsys.cpp
+++ b/Release/src/http/listener/http_server_httpsys.cpp
@@ -769,7 +769,8 @@ void windows_request_context::init_response_callbacks(ShouldWaitForBody shouldWa
 
     if (shouldWait == DontWaitForBody)
     {
-        proxy_content_ready.set();
+        // Fake a body completion so the content_ready() task doesn't keep the http_request alive forever
+        m_msg._get_impl()->_complete(0);
     }
 }
 


### PR DESCRIPTION
For Issue 13: https://github.com/Microsoft/cpprestsdk/issues/13

Here is a first cut at a refactor for the response handling to reduce cyclic reference leaks and allow error replies to propagate back to the client. I'm not 100% happy with it, the content_ready_task for example will potentially race against async_process_response if they both attempt to call cancel_request under certain error conditions. There's also no attempt to catch exceptions on the proxy_content_ready completion event, which might cause some unobserved exception issues. I've created the pull request at this early stage to facilitate discussion.