### PR TITLE
Remove unused variable

### DIFF
--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -673,7 +673,7 @@ namespace Concurrency { namespace streams
             if ( !_verify_and_return_task(details::_in_stream_msg, result) ) return result;
 
             auto copy = std::make_shared<T>();
-            return helper()->m_buffer.getn((CharType*)copy.get(), sizeof(T)).then([copy](pplx::task<size_t> op) -> T
+            return helper()->m_buffer.getn((CharType*)copy.get(), sizeof(T)).then([copy](pplx::task<size_t>) -> T
             {
                 return std::move(*copy);
             });


### PR DESCRIPTION
This is in a public header and might generate a warning.