### PR TITLE
Add unsolicited pong support with integration tests

### DIFF
--- a/Release/include/cpprest/ws_msg.h
+++ b/Release/include/cpprest/ws_msg.h
@@ -73,6 +73,15 @@ class websocket_outgoing_message
 {
 public:
 
+	/// <summary>
+	/// Sets a the outgoing message to be an unsolicited pong message.
+	/// This is useful when the client side wants to check whether the server is alive.
+	/// </summary>
+	void set_pong_message()
+	{
+		this->set_message_pong();
+	}
+
     /// <summary>
     /// Sets a UTF-8 message as the message body.
     /// </summary>
@@ -151,6 +160,14 @@ private:
     }
 
     const pplx::task_completion_event<void> & body_sent() const { return m_body_sent; }
+
+	void set_message_pong()
+	{
+		concurrency::streams::container_buffer<std::string> buffer("");
+		m_msg_type = websocket_message_type::pong;
+		m_length = static_cast<size_t>(buffer.size());
+		m_body = buffer;
+	}
 
     void set_message(const concurrency::streams::container_buffer<std::string> &buffer)
     {

--- a/Release/tests/functional/websockets/client/send_msg_tests.cpp
+++ b/Release/tests/functional/websockets/client/send_msg_tests.cpp
@@ -103,6 +103,21 @@ pplx::task<void> send_text_msg_helper(SocketClientClass& client, web::uri uri, t
     return client.send(msg);
 }
 
+template<class SocketClientClass>
+pplx::task<void> send_pong_msg_helper(SocketClientClass& client, web::uri uri, test_websocket_server& server)
+{
+	server.next_message([](test_websocket_msg msg) // Handler to verify the message sent by the client.
+	{
+		websocket_asserts::assert_message_equals(msg, "", test_websocket_message_type::WEB_SOCKET_PONG_TYPE);
+	});
+
+	client.connect(uri).wait();
+
+	websocket_outgoing_message msg;
+	msg.set_pong_message();
+	return client.send(msg);
+}
+
 pplx::task<void> send_msg_from_stream(websocket_client& client,
                                              test_websocket_server& server,
                                              web::uri uri,
@@ -455,6 +470,25 @@ TEST_FIXTURE(uri_address, send_stream_binary_msg_no_length)
 
     client.close().wait();
 }
+
+// Send an unsolicited pong message to the server
+TEST_FIXTURE(uri_address, send_pong_msg)
+{
+	test_websocket_server server;
+	websocket_client client;
+	send_pong_msg_helper(client, m_uri, server).wait();
+	client.close().wait();
+}
+
+// Send an unsolicited pong message to the server with websocket_callback_client
+TEST_FIXTURE(uri_address, send_pong_msg_callback_client)
+{
+	test_websocket_server server;
+	websocket_callback_client client;
+	send_pong_msg_helper(client, m_uri, server).wait();
+	client.close().wait();
+}
+
 
 } // SUITE(send_msg_tests)
 

--- a/Release/tests/functional/websockets/utilities/test_websocket_server.cpp
+++ b/Release/tests/functional/websockets/utilities/test_websocket_server.cpp
@@ -134,6 +134,19 @@ namespace utilities {
                 m_server_connected.set_exception(std::runtime_error("Connection attempt failed."));
             });
 
+			m_srv.set_pong_handler([this](websocketpp::connection_hdl hdl, std::string input)
+			{
+				auto fn = m_test_srv->get_next_message_handler();
+				assert(fn);
+
+				test_websocket_msg wsmsg;
+
+				wsmsg.set_data(std::vector<uint8_t>(input.begin(), input.end()));
+
+				wsmsg.set_msg_type(WEB_SOCKET_PONG_TYPE);
+				fn(wsmsg);
+			});
+
             m_srv.set_message_handler([this](websocketpp::connection_hdl hdl, server::message_ptr msg)
             {
                 auto pay = msg->get_payload();
@@ -151,12 +164,12 @@ namespace utilities {
                     wsmsg.set_msg_type(utilities::WEB_SOCKET_BINARY_MESSAGE_TYPE);
                     break;
                 case websocketpp::frame::opcode::text:
-                    wsmsg.set_msg_type(utilities::WEB_SOCKET_UTF8_MESSAGE_TYPE);
+					wsmsg.set_msg_type(utilities::WEB_SOCKET_UTF8_MESSAGE_TYPE);
                     break;
                 case websocketpp::frame::opcode::close:
                     wsmsg.set_msg_type(utilities::WEB_SOCKET_CLOSE_TYPE);
                     break;
-                default:
+				default:
                     // Websocketspp does not currently support explicit fragmentation. We should not get here.
                     std::abort();
                 }
@@ -262,7 +275,7 @@ namespace utilities {
         case test_websocket_message_type::WEB_SOCKET_CLOSE_TYPE:
             flags = websocketpp::frame::opcode::close; // WebSocket::FRAME_OP_CLOSE;
             break;
-        case test_websocket_message_type::WEB_SOCKET_UTF8_FRAGMENT_TYPE:
+		case test_websocket_message_type::WEB_SOCKET_UTF8_FRAGMENT_TYPE:
         case test_websocket_message_type::WEB_SOCKET_BINARY_FRAGMENT_TYPE:
         default:
             throw std::runtime_error("invalid message type");

--- a/Release/tests/functional/websockets/utilities/test_websocket_server.h
+++ b/Release/tests/functional/websockets/utilities/test_websocket_server.h
@@ -50,7 +50,8 @@ enum test_websocket_message_type
   WEB_SOCKET_BINARY_FRAGMENT_TYPE,
   WEB_SOCKET_UTF8_MESSAGE_TYPE,
   WEB_SOCKET_UTF8_FRAGMENT_TYPE,
-  WEB_SOCKET_CLOSE_TYPE
+  WEB_SOCKET_CLOSE_TYPE,
+  WEB_SOCKET_PONG_TYPE
 };
 
 // Interface containing details about the HTTP handshake request received by the test server.


### PR DESCRIPTION
Hi, 

This is the same as my previous pull request, but now I added integration tests. 

I added unsolicited pong support to Casablanca (see https://tools.ietf.org/html/rfc6455#section-5.5.3). This is useful for cases when the client wants to check whether the websocket connection is still up and running. For example, if I unplug my network cable, without this change, Casablanca simply does not notice that the Websocket connection is down, the close handler won't get invoked etc.

With these changes, the client can send (periodically or when certain events happen, e.g. network change events) an unsolicited pong request which has no effect on a healthy websocket connection, but will help Casablanca/WebSocket++ detect that the connection has been lost. With these changes, if I unplug my network cable and if I send a pong message after that, Casablanca correctly invokes the websocket close handler within a few seconds.

Regards,
Gergely