### PR TITLE
iOS build clang suppression list

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -134,7 +134,7 @@ elseif((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR IOS)
   message("-- Setting clang options")
 
   set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
-  set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder")
+  set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-error -Wno-unused-local-typedefs")
   set(WARNINGS "${WARNINGS} ${OSX_SUPPRESSIONS}")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")


### PR DESCRIPTION
Added "-Wno-error" and "-Wno-unused-local-typedefs" to the clang suppression list into Release/CMakeLists.xtx. It solves build problems on iOS.

Without this options the build process on iOS fails.