### PR TITLE
Add TLS extension SNI for boost asio based http_client

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -35,4 +35,7 @@ Gery Vessere (gery@vessere.com)
 Cisco Systems
 Gergely Lukacsy (glukacsy)
 
+Ocedo GmbH
+Henning Pfeiffer (megaposer)
+
 thomasschaub

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -101,7 +101,7 @@ public:
         , m_set_user_nativehandle_options([](native_handle)->void{})
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_ssl_context_callback([](boost::asio::ssl::context&)->void{})
-        , m_tlsext_host_name(true)
+        , m_tlsext_sni_enabled(true)
 #endif
 #if defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_buffer_request(false)
@@ -350,22 +350,22 @@ public:
     }
 
     /// <summary>
-    /// Gets the TLS server name indication (SNI) property.
+    /// Gets the TLS extension server name indication (SNI) status.
     /// </summary>
     /// <returns>True if TLS server name indication is enabled, false otherwise.</returns>
-    bool tlsext_host_name() const
+    bool is_tlsext_sni_enabled() const
     {
-        return m_tlsext_host_name;
+        return m_tlsext_sni_enabled;
     }
 
     /// <summary>
-    /// Sets the TLS server name indication (SNI) property.
+    /// Sets the TLS extension server name indication (SNI) status.
     /// </summary>
-    /// <param name="tlsext_host_name">False to disable the TLS (ClientHello) extension for server name indication, true otherwise.</param>
-    /// <remarks>Note: This setting is required in most virtual hosting scenarios.</remarks>
-    void set_tlsext_host_name(bool tlsext_host_name)
+    /// <param name="tlsext_sni_enabled">False to disable the TLS (ClientHello) extension for server name indication, true otherwise.</param>
+    /// <remarks>Note: This setting is enabled by default as it is required in most virtual hosting scenarios.</remarks>
+    void set_tlsext_sni_enabled(bool tlsext_sni_enabled)
     {
-        m_tlsext_host_name = tlsext_host_name;
+        m_tlsext_sni_enabled = tlsext_sni_enabled;
     }
 #endif
 
@@ -392,7 +392,7 @@ private:
 
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
     std::function<void(boost::asio::ssl::context&)> m_ssl_context_callback;
-    bool m_tlsext_host_name;
+    bool m_tlsext_sni_enabled;
 #endif
 #if defined(_WIN32) && !defined(__cplusplus_winrt)
     bool m_buffer_request;

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -101,6 +101,7 @@ public:
         , m_set_user_nativehandle_options([](native_handle)->void{})
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_ssl_context_callback([](boost::asio::ssl::context&)->void{})
+        , m_tlsext_host_name(true)
 #endif
 #if defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_buffer_request(false)
@@ -347,6 +348,25 @@ public:
     {
         return m_ssl_context_callback;
     }
+
+    /// <summary>
+    /// Gets the TLS server name indication (SNI) property.
+    /// </summary>
+    /// <returns>True if TLS server name indication is enabled, false otherwise.</returns>
+    bool tlsext_host_name() const
+    {
+        return m_tlsext_host_name;
+    }
+
+    /// <summary>
+    /// Sets the TLS server name indication (SNI) property.
+    /// </summary>
+    /// <param name="tlsext_host_name">False to disable the TLS (ClientHello) extension for server name indication, true otherwise.</param>
+    /// <remarks>Note: This setting is required in most virtual hosting scenarios.</remarks>
+    void set_tlsext_host_name(bool tlsext_host_name)
+    {
+        m_tlsext_host_name = tlsext_host_name;
+    }
 #endif
 
 private:
@@ -372,6 +392,7 @@ private:
 
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
     std::function<void(boost::asio::ssl::context&)> m_ssl_context_callback;
+    bool m_tlsext_host_name;
 #endif
 #if defined(_WIN32) && !defined(__cplusplus_winrt)
     bool m_buffer_request;

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -155,7 +155,7 @@ public:
         }
 
         // Check to set host name for Server Name Indication (SNI)
-        if (config.tlsext_host_name())
+        if (config.is_tlsext_sni_enabled())
         {
             SSL_set_tlsext_host_name(m_ssl_stream->native_handle(), const_cast<char *>(host_name.data()));
         }


### PR DESCRIPTION
As per reported issue #35 ...

This adds the TLS 1.0 server name indication extension for the boost asio based http_client. The _ClientHello_ packet in the SSL handshake will then contain the target host name so the remote server can return the corresponding certificate for the (virtual) host.

See https://en.wikipedia.org/wiki/Server_Name_Indication for more information.

The extension is enabled by default as most virtual host environments require it nowadays. 

Please note:
* Setting the extension could potentially fail silently (i.e. if TLS 1.0 is explicitly disabled on the asio SSL stream object altogether).
* This setting is not applicable to the Windows http_client implementation. The `WinHTTP` library enables TLS 1.0 on connections with Windows 7 and higher and implicitly sends the SNI extension in the _ClientHello_. Disabling SNI requires to explicitly unset the `WINHTTP_FLAG_SECURE_PROTOCOL_TLS1` option via a native callback handler.