### PR TITLE
Overwrite HTTP Host header

### DIFF
--- a/Release/include/cpprest/details/http_client_impl.h
+++ b/Release/include/cpprest/details/http_client_impl.h
@@ -57,6 +57,11 @@ static utility::string_t flatten_http_headers(const http_headers &headers)
     utility::string_t flattened_headers;
     for(auto iter = headers.begin(); iter != headers.end(); ++iter)
     {
+        utility::string_t header_name = iter->first;
+        http_headers::_case_insensitive_cmp cmp;
+        if (!cmp(header_name, "host") && !cmp("host", header_name)) {
+            continue;
+        }
         flattened_headers.append(iter->first);
         flattened_headers.push_back(':');
         flattened_headers.append(iter->second);

--- a/Release/include/cpprest/details/http_client_impl.h
+++ b/Release/include/cpprest/details/http_client_impl.h
@@ -59,7 +59,7 @@ static utility::string_t flatten_http_headers(const http_headers &headers)
     {
         utility::string_t header_name = iter->first;
         http_headers::_case_insensitive_cmp cmp;
-        if (!cmp(header_name, "host") && !cmp("host", header_name)) {
+        if (!cmp(header_name, header_names::host) && !cmp(header_names::host, header_name)) {
             continue;
         }
         flattened_headers.append(iter->first);

--- a/Release/include/cpprest/details/http_client_impl.h
+++ b/Release/include/cpprest/details/http_client_impl.h
@@ -58,8 +58,7 @@ static utility::string_t flatten_http_headers(const http_headers &headers)
     for(auto iter = headers.begin(); iter != headers.end(); ++iter)
     {
         utility::string_t header_name = iter->first;
-        http_headers::_case_insensitive_cmp cmp;
-        if (!cmp(header_name, header_names::host) && !cmp(header_names::host, header_name)) {
+        if (utility::details::str_icmp(header_name, header_names::host)) {
             continue;
         }
         flattened_headers.append(iter->first);

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -394,14 +394,21 @@ public:
         std::ostream request_stream(&m_body_buf);
         request_stream.imbue(std::locale::classic());
 
-        request_stream << method << " " << encoded_resource << " " << "HTTP/1.1" << CRLF << "Host: " << host;
+        request_stream << method << " " << encoded_resource << " " << "HTTP/1.1" << CRLF;
+        request_stream << "Host: ";
 
         int port = base_uri.port();
         if (base_uri.is_port_default())
         {
             port = (m_connection->is_ssl() ? 443 : 80);
         }
-        request_stream << ":" << port << CRLF;
+
+        std::string specified_host_header;
+        if (m_request.headers().match(header_names::host, specified_host_header)) {
+            request_stream << specified_host_header << CRLF;
+        } else {
+            request_stream << host << ":" << port << CRLF;
+        }
 
         // Extra request headers are constructed here.
         utility::string_t extra_headers;

--- a/Release/tests/functional/http/client/header_tests.cpp
+++ b/Release/tests/functional/http/client/header_tests.cpp
@@ -382,6 +382,37 @@ TEST_FIXTURE(uri_address, parsing_content_type_redundantsemicolon_string)
     auto resp = client.request(methods::GET).get();
     VERIFY_ARE_EQUAL(resp.extract_string().get(), utility::conversions::to_string_t(body));
 }
+
+TEST_FIXTURE(uri_address, overwrite_http_header)
+{
+    test_http_server::scoped_server scoped(m_uri);
+    http_client client(m_uri);
+    
+    // Test default case of cpprestsdk setting host header as host:port
+    auto& host = m_uri.host();
+    int port = m_uri.port();
+    utility::string_t expected_default_header = host + ":" + std::to_string(port);
+    http_request default_host_headers_request(methods::GET);
+    scoped.server()->next_request().then([&](test_request *p_request) 
+    {
+        auto headers = p_request->m_headers;
+        VERIFY_ARE_EQUAL(expected_default_header, headers[header_names::host]);
+        p_request->reply(200);
+    });
+
+    client.request(default_host_headers_request).get();
+
+    // Test case where we overwrite the host header
+    http_request overwritten_host_headers_request(methods::GET);
+    overwritten_host_headers_request.headers().add("Host", host);
+    scoped.server()->next_request().then([&](test_request *p_request)
+    {
+        auto headers = p_request->m_headers;
+        VERIFY_ARE_EQUAL(host, headers[header_names::host]);
+        p_request->reply(200);
+    });
+    client.request(overwritten_host_headers_request).get();
+}
 } // SUITE(header_tests)
 
 }}}}


### PR DESCRIPTION
Currently, cpprestsdk ouputs the host header in the form of 'Host: hostname:port'

    Example: Host : microsoft.com:443

Some servers have trouble handling the port number on the host header. It might be useful to allow overriding the host header (like curl does). This PR allows us to specify a host header in our request. If present, it will print that out on the http request. Else, it will default to the current host:port format