### PR TITLE
Fixed build on CentOS 7 Linux

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -7,6 +7,8 @@ enable_testing()
 set(WARNINGS)
 set(ANDROID_STL_FLAGS)
 
+option(WERROR "Threat Warnings as Errors" ON)
+
 # Platform (not compiler) specific settings
 if(IOS)
   set(IOS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../Build_iOS")
@@ -73,7 +75,7 @@ elseif(ANDROID)
   set(BUILD_SAMPLES OFF)
   option(BUILD_TESTS "Build tests." ON)
 elseif(UNIX) # This includes OSX
-  find_package(Boost REQUIRED COMPONENTS random chrono system thread regex filesystem)
+  find_package(Boost 1.54 REQUIRED COMPONENTS random chrono system thread regex filesystem)
   find_package(Threads REQUIRED)
   if(APPLE AND NOT OPENSSL_ROOT_DIR)
     # Prefer a homebrew version of OpenSSL over the one in /usr/lib
@@ -190,14 +192,7 @@ endif()
 
 set(Casablanca_LIBRARY ${LIB}cpprest)
 set(Casablanca_LIBRARIES ${Casablanca_LIBRARY}
-  ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
-  ${Boost_THREAD_LIBRARY}
-  ${Boost_ATOMIC_LIBRARY}
-  ${Boost_CHRONO_LIBRARY}
-  ${Boost_RANDOM_LIBRARY}
-  ${Boost_REGEX_LIBRARY}
-  ${Boost_FRAMEWORK})
+  ${Boost_LIBRARIES})
 
 # Everything in the project needs access to the casablanca include directories
 include_directories(${Casablanca_INCLUDE_DIRS})

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -53,7 +53,11 @@ if(UNIX)
   else()
     list(APPEND SOURCES pplx/pplxlinux.cpp)
   endif()
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS} -Werror -pedantic")
+
+  if(WERROR)
+      set(WARNINGS "${WARNINGS} -Werror")
+  endif()
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS} -pedantic")
 elseif(WIN32)
   set(SOURCES
     ${SOURCES_COMMON}

--- a/Release/tests/common/TestRunner/CMakeLists.txt
+++ b/Release/tests/common/TestRunner/CMakeLists.txt
@@ -17,9 +17,7 @@ if(NOT IOS AND NOT ANDROID)
       )
 
     target_link_libraries(test_runner
-      ${Boost_FRAMEWORK}
-      ${Boost_SYSTEM_LIBRARY}
-      ${Boost_FILESYSTEM_LIBRARY}
+      ${Boost_LIBRARIES}
       ${LIB}unittestpp
       ${CMAKE_DL_LIBS}
       )
@@ -31,9 +29,7 @@ if(NOT IOS AND NOT ANDROID)
         )
 
       target_link_libraries(test_runner
-        ${Boost_FRAMEWORK}
-        ${Boost_SYSTEM_LIBRARY}
-        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_LIBRARIES}
         ${LIB}unittestpp
         ${CMAKE_DL_LIBS}
         -Wl,-force_load
@@ -64,9 +60,7 @@ if(NOT IOS AND NOT ANDROID)
         )
 
       target_link_libraries(test_runner
-        ${Boost_FRAMEWORK}
-        ${Boost_SYSTEM_LIBRARY}
-        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_LIBRARIES}
         ${LIB}unittestpp
         ${CMAKE_DL_LIBS}
         -Wl,--whole-archive

--- a/Release/tests/functional/http/client/proxy_tests.cpp
+++ b/Release/tests/functional/http/client/proxy_tests.cpp
@@ -46,7 +46,7 @@ TEST_FIXTURE(uri_address, auto_discovery_proxy)
         p_request->reply(200);
     });
     http_client_config config;
-    
+
     config.set_proxy(web_proxy::use_auto_discovery);
     VERIFY_IS_FALSE(config.proxy().is_disabled());
     VERIFY_IS_FALSE(config.proxy().is_specified());
@@ -63,7 +63,7 @@ TEST_FIXTURE(uri_address, disabled_proxy)
         http_asserts::assert_test_request_equals(p_request, methods::PUT, U("/"), U("text/plain"), U("sample data"));
         p_request->reply(status_codes::OK);
     });
-    
+
     http_client_config config;
     config.set_proxy(web_proxy(web_proxy::disabled));
     VERIFY_IS_TRUE(config.proxy().is_disabled());
@@ -97,13 +97,13 @@ TEST_FIXTURE(uri_address, no_proxy_options_on_winrt)
     web_proxy proxy(u);
     VERIFY_IS_TRUE(proxy.is_specified());
     VERIFY_ARE_EQUAL(u, proxy.address());
-    credentials cred(U("artur"), U("fred")); // relax, this is not my real password
+    web::credentials cred(U("artur"), U("fred")); // relax, this is not my real password
     proxy.set_credentials(cred);
 
     http_client_config config;
     config.set_proxy(proxy);
 
-    // Access to this server will succeed because the first request will not be challenged and hence 
+    // Access to this server will succeed because the first request will not be challenged and hence
     // my bogus credentials will not be supplied.
     http_client client(U("http://www.microsoft.com"), config);
 


### PR DESCRIPTION
Here the changes which allows to build cpprestsdk on CentOS Linux 7 (x86_64) with g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-4)

- added WERROR option to cmake which controls -Werror option (-DWERROR=ON/OFF)
- using Boost_LIBRARIES instead of multiple libs mentions
- enforcing Boost v1.54 (boost asio library with less version does not have ssl::context::use_private_key)
- web::credentials clashes with krb.h definition (see below) 

```
proxy_tests.cpp:100:5: error: reference to ‘credentials’ is ambiguous
     credentials cred(U("artur"), U("fred")); // relax, this is not my real password
     ^
In file included from /usr/include/krb5.h:8:0,
                 from /usr/include/openssl/kssl.h:72,
                 from /usr/include/openssl/ssl.h:165,
                 from /usr/include/boost/asio/ssl/detail/openssl_types.hpp:20,
                 from /usr/include/boost/asio/ssl/context_base.hpp:20,
                 from /usr/include/boost/asio/ssl/context.hpp:26,
                 from /usr/include/boost/asio/ssl.hpp:19,
                 from /home/snikulov/work/github/casa/cpprestsdk/Release/include/cpprest/http_client.h:65,
                 from /home/snikulov/work/github/casa/cpprestsdk/Release/tests/functional/http/client/stdafx.h:26,
                 from /home/snikulov/work/github/casa/cpprestsdk/Release/tests/functional/http/client/proxy_tests.cpp:26:
/usr/include/krb5/krb5.h:4135:8: note: candidates are: struct credentials
 struct credentials;

```