### PR TITLE
fix build failure on linux

### DIFF
--- a/Release/tests/functional/http/client/proxy_tests.cpp
+++ b/Release/tests/functional/http/client/proxy_tests.cpp
@@ -97,7 +97,7 @@ TEST_FIXTURE(uri_address, no_proxy_options_on_winrt)
     web_proxy proxy(u);
     VERIFY_IS_TRUE(proxy.is_specified());
     VERIFY_ARE_EQUAL(u, proxy.address());
-    credentials cred(U("artur"), U("fred")); // relax, this is not my real password
+    web::credentials cred(U("artur"), U("fred")); // relax, this is not my real password
     proxy.set_credentials(cred);
 
     http_client_config config;


### PR DESCRIPTION
[ 46%] Building CXX object tests/functional/http/client/CMakeFiles/httpclient_test.dir/proxy_tests.cpp.o
/home/ritesh/Projects/github/Microsoft/cpprestsdk/Release/tests/functional/http/client/proxy_tests.cpp: In member function ‘void tests::functional::http::client::Suiteproxy_tests::uri_addresshttp_proxy_with_credentialsHelper::RunImpl()’:
proxy_tests.cpp:100:5: error: reference to ‘credentials’ is ambiguous
     credentials cred(U("artur"), U("fred")); // relax, this is not my real password
     ^~~~~~~~~~~
/usr/include/krb5/krb5.h:4182:8: note: candidates are: struct credentials

/home/ritesh/Projects/github/Microsoft/cpprestsdk/Release/include/cpprest/details/web_utilities.h:81:7: note: class web::credentials



