### PR TITLE
Basic auth asio on Linux

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -633,7 +633,12 @@ public:
             {
                 extra_headers.append(ctx->generate_basic_proxy_auth_header());
             }
-                
+
+            if (ctx->m_http_client->client_config().credentials().is_set())
+            {
+                extra_headers.append(ctx->generate_basic_auth_header());
+            }
+
             // Check user specified transfer-encoding.
             std::string transferencoding;
             if (ctx->m_request.headers().match(header_names::transfer_encoding, transferencoding) && transferencoding == "chunked")
@@ -732,6 +737,23 @@ public:
     }
 
 private:
+    utility::string_t generate_basic_auth_header()
+    {
+        utility::string_t header;
+
+        header.append(header_names::authorization);
+        header.append(": Basic ");
+
+        auto credential_str = web::details::plaintext_string(new ::utility::string_t(m_http_client->client_config().credentials().username()));
+        credential_str->append(":");
+        credential_str->append(*m_http_client->client_config().credentials().decrypt());
+
+        std::vector<unsigned char> credentials_buffer(credential_str->begin(), credential_str->end());
+
+        header.append(utility::conversions::to_base64(credentials_buffer));
+        header.append(CRLF);
+        return header;
+    }
 
     utility::string_t generate_basic_proxy_auth_header()
     {

--- a/Release/tests/functional/http/client/authentication_tests.cpp
+++ b/Release/tests/functional/http/client/authentication_tests.cpp
@@ -620,6 +620,37 @@ TEST_FIXTURE(uri_address, failed_authentication_attempt, "Ignore:Linux", "89", "
 
 #if !defined(_WIN32)
 
+// http_server does not support auth
+void auth_test_impl(bool fail)
+{
+    std::string user("user1"), password("user1");
+    auto return_code = status_codes::NotFound; // return 404 if successful auth
+
+    if (fail)
+    {
+        password = "invalid";
+        return_code = status_codes::Unauthorized;
+    }
+
+    http_client_config client_config;
+    web::credentials cred(U(user), U(password));
+    client_config.set_credentials(cred);
+    http_client client(U("http://test.webdav.org/auth-basic/"), client_config);
+
+    http_response response = client.request(methods::GET).get();
+    VERIFY_ARE_EQUAL(return_code, response.status_code());
+}
+
+TEST(auth_no_data)
+{
+    auth_test_impl(false);
+}
+
+TEST(unsuccessful_auth_with_basic_cred)
+{
+    auth_test_impl(true);
+}
+
 TEST_FIXTURE(uri_address, set_user_options_asio_http)
 {
     test_http_server::scoped_server scoped(m_uri);


### PR DESCRIPTION
Add support for basic auth for http_client_asio on Linux

		auto creds = web::http::client::credentials(user, password);
		client_config.set_credentials(creds);

		m_client = std::unique_ptr<web::http::client::http_client > \
			(new web::http::client::http_client (server, client_config));
		
		auto task = m_client->request(web::http::methods::POST, api_path);
		task.then([](web::http::http_response response) {
			std::cout << "response is " << response.to_string()  << "\n";
		});
		task.wait();
