### PR TITLE
Fixing latin1 to UTF-16 convertion

### DIFF
--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -440,7 +440,7 @@ utf16string __cdecl conversions::latin1_to_utf16(const std::string &s)
     dest.resize(s.size());
     for (size_t i = 0; i < s.size(); ++i)
     {
-        dest[i] = utf16char(s[i]);
+        dest[i] = utf16char(static_cast<unsigned char>(s[i]));
     }
     return dest;
 }

--- a/Release/tests/functional/utils/strings.cpp
+++ b/Release/tests/functional/utils/strings.cpp
@@ -278,13 +278,22 @@ TEST(utf8_to_utf16_errors)
 
 TEST(latin1_to_utf16)
 {
-    // TODO: find some string that actually uses something unique to the Latin1 code page.
-    std::string str_latin1("This is a test");
-    utf16string str_utf16 = utility::conversions::latin1_to_utf16(str_latin1);
-    
-    for (size_t i = 0; i < str_latin1.size(); ++i)
+    char in[256] = { 0 };
+    char16_t expectedResult[256] = { 0 };
+    for (size_t i = 0; i < 256; ++i)
     {
-        VERIFY_ARE_EQUAL((utf16char)str_latin1[i], str_utf16[i]);
+        in[i] = static_cast<char>(i);
+        expectedResult[i] = static_cast<char16_t>(i);
+    }
+
+    std::string str_latin1(in, 256);
+
+    auto actualResult = utility::conversions::latin1_to_utf16(str_latin1);
+
+    VERIFY_ARE_EQUAL(str_latin1.size(), actualResult.size());
+    for (size_t i = 0; i < actualResult.size(); ++i)
+    {
+        VERIFY_ARE_EQUAL(expectedResult[i], actualResult[i]);
     }
 }
 


### PR DESCRIPTION
As I described in #101, I found bug in `utility::conversions::latin1_to_utf16`, when trying to convert string containing 'í' character (0xed). Signed character is being casted and it leads to result containing 0xff as first byte instead of 0x00 (example for input char 0xed: 0xffed instead of 0x00ed which is correct UTF-16 encoded 'í' character).
This bug affects strings containing any characters above 0x80 (negative numbers in signed `char`).