### PR TITLE
Fix a memory leak issue

### DIFF
--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -602,13 +602,10 @@ void connection::dispatch_request_to_listener()
             m_request._reply_if_not_already(status_codes::InternalError);
         }
     }
-    
-    if (--m_refs == 0) delete this;
 }
 
 void connection::do_response(bool bad_request)
 {
-    ++m_refs;
     m_request.get_response().then([=](pplx::task<http::http_response> r_task)
     {
         http::http_response response;
@@ -795,7 +792,15 @@ void connection::finish_request_response()
     }
     
     close();
-    if (--m_refs == 0) delete this;
+
+    if (--m_refs == 0)
+    {
+        delete this;
+    }
+    else
+    {
+        printf(stderr, "!!! m_refs = %d in finish_request_response, %s \n", (int)m_refs, m_request.request_uri().path().c_str());
+    }
 }
 
 void hostport_listener::stop()

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -799,7 +799,7 @@ void connection::finish_request_response()
     }
     else
     {
-        printf(stderr, "!!! m_refs = %d in finish_request_response, %s \n", (int)m_refs, m_request.request_uri().path().c_str());
+        throw std::runtime_error("m_refs != 0 in finish_request_response, memory leak detected!");
     }
 }
 


### PR DESCRIPTION
This change fixed a memory leak in the implementation of connection pool.
The original implementation uses a ref count for managing the lifetime of each connection, but the connection object is definitely lost reported by valgrind.
Investigation showing that the m_refs field is added by do_response twice, so in the end of finish_request_response method, it equals 1.
This change fixed the issue by just delete the instance at the end of finish_request_response method.
