### PR TITLE
Add certificate pinning capabilities to WinHttp

### DIFF
--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -84,6 +84,8 @@ namespace client
 using web::credentials;
 using web::web_proxy;
 
+using PinningCallBackFunction = std::function<bool(const utility::string_t&, const utility::string_t&)>;
+
 /// <summary>
 /// HTTP client configuration class, used to set the possible configuration options
 /// used to create an http_client instance.
@@ -98,7 +100,8 @@ public:
 #if !defined(__cplusplus_winrt)
         , m_validate_certificates(true)
 #endif
-        , m_set_user_nativehandle_options([](native_handle)->void{})
+		, m_certificate_pinning_callback([](const utility::string_t&, const utility::string_t&)->bool { return true; }) // by default certificate pinning returns success
+		, m_set_user_nativehandle_options([](native_handle)->void {})
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_ssl_context_callback([](boost::asio::ssl::context&)->void{})
         , m_tlsext_sni_enabled(true)
@@ -329,6 +332,26 @@ public:
         m_set_user_nativehandle_options(handle);
     }
 
+	/// <summary>
+	/// Set the certificate pinning callback. If set, HTTP client will call this callback in a blocking manner during HTTP connection.
+	/// </summary>
+	void set_user_certificate_pinning_callback(const PinningCallBackFunction& callback)
+	{
+		m_certificate_pinning_callback = callback;
+	}
+
+	/// <summary>
+	/// Invokes the certificate pinning callback.
+	/// </summary>
+	/// <param name="url">The URL in the actual TLS session which might be different than the original URL due to redirection.</param>
+	/// <param name="certificate">The public key of one of the certificate in the chain presented to the consumer for validation purposes.</param>
+	/// <returns>True if the consumer code validated the certificate, false otherwise. False will terminate the HTTP connection.</returns>
+	bool invoke_pinning_callback(const utility::string_t& url, const utility::string_t& public_key) const
+	{
+		return m_certificate_pinning_callback(url, public_key);
+	}
+
+
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
     /// <summary>
     /// Sets a callback to enable custom setting of the ssl context, at construction time.
@@ -386,6 +409,7 @@ private:
     bool m_validate_certificates;
 #endif
 
+	PinningCallBackFunction m_certificate_pinning_callback;
     std::function<void(native_handle)> m_set_user_nativehandle_options;
 
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)


### PR DESCRIPTION
This is a preliminary pull request to see if you guys are happy to add this to Casablanca. Essentially, due to security requirements, we are using certificate pinning and needed to expose this functionality in Casablanca. 

On a high level all we are doing here is letting the consumer register a callback which will be called back for each certificate retrieved during the TLS negotiation. The consumer then compare these against a hardcoded list of valid public keys and make a yes/no decision. If all certificates are rejected, the connection is cancelled. 

The reason we need to walk the chain (and which makes the code complex) is that in most cases we don't want to pin to the leaf cerrtificate, but rather to an intermediate one (because the leaf certificates change too often). 

Let me know if on a high level this is in line with what you have in mind regarding design. In the meantim I will work on doing the same for OS X.

Regards,
Gergely
