### PR TITLE
Revert "Removing no longer needed files for building libiconv for Android"

### DIFF
--- a/Build_android/configure.sh
+++ b/Build_android/configure.sh
@@ -187,7 +187,7 @@ then
 	    git apply "$DIR/boost-for-android.patch"
 	    touch cpprestsdk.patched.stamp
 	fi
-	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=locale,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
+	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=atomic,locale,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
     )
 
     (
@@ -204,7 +204,7 @@ then
 	    ln -s ../Boost-for-Android/boost_1_55_0.tar.bz2 .
 	    touch cpprestsdk.patched.stamp
 	fi
-	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=locale,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
+	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=atomic,locale,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
     )
 )
 fi

--- a/Build_android/libiconv/jni/Android.mk
+++ b/Build_android/libiconv/jni/Android.mk
@@ -1,0 +1,23 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE    := iconv
+LOCAL_CFLAGS    := \
+    -Wno-multichar \
+    -D_ANDROID \
+    -DLIBDIR="\"c\"" \
+    -DBUILDING_LIBICONV \
+    -DIN_LIBRARY \
+    -Wno-static-in-inline \
+    -Wno-tautological-compare \
+    -Wno-parentheses-equality
+
+LOCAL_C_INCLUDES := \
+    ${LOCAL_PATH}/../libiconv-1.13.1 \
+    ${LOCAL_PATH}/../libiconv-1.13.1/include \
+    ${LOCAL_PATH}/../libiconv-1.13.1/lib \
+    ${LOCAL_PATH}/../libiconv-1.13.1/libcharset/include
+LOCAL_SRC_FILES := \
+    ../libiconv-1.13.1/lib/iconv.c \
+    ../libiconv-1.13.1/lib/relocatable.c \
+    ../libiconv-1.13.1/libcharset/lib/localcharset.c
+include $(BUILD_STATIC_LIBRARY)

--- a/Build_android/libiconv/jni/Application.mk
+++ b/Build_android/libiconv/jni/Application.mk
@@ -1,0 +1,3 @@
+NDK_TOOLCHAIN_VERSION := clang
+APP_PLATFORM := android-9
+APP_ABI := armeabi-v7a x86

--- a/Build_android/libiconv/libiconv.patch
+++ b/Build_android/libiconv/libiconv.patch
@@ -1,0 +1,22 @@
+diff --ignore-file-name-case -wuprN libiconv-1.13.1.orig/libcharset/lib/localcharset.c libiconv-1.13.1/libcharset/lib/localcharset.c
+--- libiconv-1.13.1.orig/libcharset/lib/localcharset.c  2009-06-21 07:17:33.000000000 -0400
++++ libiconv-1.13.1/libcharset/lib/localcharset.c       2012-12-18 10:20:27.000000000 -0500
+@@ -44,7 +44,7 @@
+ # endif
+ #endif
+
+-#if !defined WIN32_NATIVE
++#if !defined(WIN32_NATIVE) && !defined(__ANDROID__)
+ # if HAVE_LANGINFO_CODESET
+ #  include <langinfo.h>
+ # else
+@@ -328,7 +328,7 @@ locale_charset (void)
+   const char *codeset;
+   const char *aliases;
+
+-#if !(defined WIN32_NATIVE || defined OS2)
++#if !(defined WIN32_NATIVE || defined OS2 || defined __ANDROID__)
+
+ # if HAVE_LANGINFO_CODESET " > iconv.patch
+
+   $ patch -b -p0 < ./iconv.patch


### PR DESCRIPTION
This reverts commit 0dd86b11535d8db64c5a7409b1622d71bfbb21f6.

It also adds the missing boost atomic and bumps the clang to use the most recent version. With these changes, the compilation for android under Linux now works as expected.

Fixes #85 