### PR TITLE
Fix android build script for linux

### DIFF
--- a/Build_android/boost-for-android-x86.patch
+++ b/Build_android/boost-for-android-x86.patch
@@ -13,29 +13,17 @@ index 40453f7..7ffc050 100755
 +		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 +		TOOLSET=clang-androidR8e
 +                ;;
-+	"10e-rc4 (64-bit)")
++	"10e-rc4 (64-bit)"|"10e (64-bit)")
 +		TOOLCHAIN=llvm-3.6
 +		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 +		TOOLSET=clang-androidR8e
                  ;;
  	*)
  		echo "Undefined or not supported Android NDK version!"
-@@ -392,6 +397,7 @@ echo "Building boost for android"
-   export PATH=$AndroidBinariesPath:$PATH
-   export AndroidNDKRoot
-   export NO_BZIP2=1
-+  export ICONV_PATH="`pwd`/../../libiconv/x86"
- 
-   cxxflags=""
-   for flag in $CXXFLAGS; do cxxflags="$cxxflags cxxflags=$flag"; done
-@@ -404,8 +410,12 @@ echo "Building boost for android"
+@@ -404,8 +409,8 @@ echo "Building boost for android"
           threading=multi              \
           --layout=versioned           \
           --prefix="./../$BUILD_DIR/"  \
-+         boost.locale.posix=off       \
-+         boost.locale.std=on          \
-+         boost.locale.iconv=on        \
-+         boost.locale.icu=off         \
           $LIBRARIES                   \
 -         install 2>&1                 \
 +         release debug install 2>&1   \
@@ -98,7 +86,7 @@ index 666d4c8..762753e 100644
 +<linkflags>--sysroot=$(AndroidNDKRoot)/platforms/android-9/arch-x86
  # @Moss - Above are the 'oficial' android flags
 -<architecture>arm
-+#<architecture>i686
++<architecture>i686
  <compileflags>-fvisibility=hidden
  <compileflags>-fvisibility-inlines-hidden
  <compileflags>-fdata-sections

--- a/Build_android/boost-for-android-x86.patch
+++ b/Build_android/boost-for-android-x86.patch
@@ -20,8 +20,15 @@ index 40453f7..7ffc050 100755
                  ;;
  	*)
  		echo "Undefined or not supported Android NDK version!"
-@@ -404,8 +409,8 @@ echo "Building boost for android"
-          threading=multi              \
+@@ -391,6 +396,7 @@ echo "Building boost for android"
+   export AndroidBinariesPath=`dirname $CXXPATH`
+   export PATH=$AndroidBinariesPath:$PATH
+   export AndroidNDKRoot
++  export PlatformOS
+   export NO_BZIP2=1
+
+   cxxflags=""
+@@ -405,7 +411,7 @@ echo "Building boost for android"
           --layout=versioned           \
           --prefix="./../$BUILD_DIR/"  \
           $LIBRARIES                   \
@@ -31,11 +38,14 @@ index 40453f7..7ffc050 100755
    } | tee -a $PROGDIR/build.log
  
 diff --git a/configs/user-config-boost-1_55_0.jam b/configs/user-config-boost-1_55_0.jam
-index 666d4c8..762753e 100644
+index 666d4c8..4cd3441 100644
 --- a/configs/user-config-boost-1_55_0.jam
 +++ b/configs/user-config-boost-1_55_0.jam
-@@ -41,91 +41,44 @@ import os ;
+@@ -39,93 +39,47 @@
+
+ import os ;
  local AndroidNDKRoot = [ os.environ AndroidNDKRoot ] ;
++local PlatformOS = [ os.environ PlatformOS ] ;
  
  # --------------------------------------------------------------------
 -# Is same for 8b, 8c and 8d
@@ -43,10 +53,10 @@ index 666d4c8..762753e 100644
 +using clang : androidR8e
  :
 -arm-linux-androideabi-g++
-+$(AndroidNDKRoot)/toolchains/llvm-3.6/prebuilt/linux-x86_64/bin/clang++
++$(AndroidNDKRoot)/toolchains/llvm-3.6/prebuilt/$(PlatformOS)-x86_64/bin/clang++
  :
 -<archiver>arm-linux-androideabi-ar
-+<compileflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/x86-4.8/prebuilt/linux-x86_64"
++<compileflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/x86-4.8/prebuilt/$(PlatformOS)-x86_64"
  <compileflags>-fexceptions
  <compileflags>-frtti
  <compileflags>-fpic
@@ -82,7 +92,7 @@ index 666d4c8..762753e 100644
 +<compileflags>-I$(AndroidNDKRoot)/sources/cxx-stl/gnu-libstdc++/4.8/include
 +<compileflags>-I$(AndroidNDKRoot)/sources/cxx-stl/gnu-libstdc++/4.8/libs/x86/include
 +<linkflags>--target=i686-none-linux-android
-+<linkflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/x86-4.8/prebuilt/linux-x86_64"
++<linkflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/x86-4.8/prebuilt/$(PlatformOS)-x86_64"
 +<linkflags>--sysroot=$(AndroidNDKRoot)/platforms/android-9/arch-x86
  # @Moss - Above are the 'oficial' android flags
 -<architecture>arm

--- a/Build_android/boost-for-android.patch
+++ b/Build_android/boost-for-android.patch
@@ -20,7 +20,15 @@ index 40453f7..ad78ddf 100755
                  ;;
  	*)
  		echo "Undefined or not supported Android NDK version!"
-@@ -404,8 +409,8 @@ echo "Building boost for android"
+@@ -391,6 +396,7 @@ echo "Building boost for android"
+   export AndroidBinariesPath=`dirname $CXXPATH`
+   export PATH=$AndroidBinariesPath:$PATH
+   export AndroidNDKRoot
++  export PlatformOS
+   export NO_BZIP2=1
+
+   cxxflags=""
+@@ -405,7 +411,7 @@ echo "Building boost for android"
           threading=multi              \
           --layout=versioned           \
           --prefix="./../$BUILD_DIR/"  \
@@ -34,19 +42,22 @@ diff --git a/configs/user-config-boost-1_55_0.jam b/configs/user-config-boost-1_
 index 666d4c8..df597f6 100644
 --- a/configs/user-config-boost-1_55_0.jam
 +++ b/configs/user-config-boost-1_55_0.jam
-@@ -41,82 +41,41 @@ import os ;
+@@ -39,84 +39,44 @@
+
+ import os ;
  local AndroidNDKRoot = [ os.environ AndroidNDKRoot ] ;
- 
++local PlatformOS = [ os.environ PlatformOS ] ;
+
  # --------------------------------------------------------------------
 -# Is same for 8b, 8c and 8d
 -using gcc : androidR8b
 +using clang : androidR8e
  :
 -arm-linux-androideabi-g++
-+$(AndroidNDKRoot)/toolchains/llvm-3.6/prebuilt/linux-x86_64/bin/clang++
++$(AndroidNDKRoot)/toolchains/llvm-3.6/prebuilt/$(PlatformOS)-x86_64/bin/clang++
  :
 -<archiver>arm-linux-androideabi-ar
-+<compileflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64"
++<compileflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/arm-linux-androideabi-4.8/prebuilt/$(PlatformOS)-x86_64"
  <compileflags>-fexceptions
  <compileflags>-frtti
  <compileflags>-fpic
@@ -126,7 +137,7 @@ index 666d4c8..df597f6 100644
 +<compileflags>-I$(AndroidNDKRoot)/sources/cxx-stl/gnu-libstdc++/4.8/include
 +<compileflags>-I$(AndroidNDKRoot)/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi/include
 +<linkflags>--target=armv7-none-linux-androideabi
-+<linkflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64"
++<linkflags>--gcc-toolchain="$(AndroidNDKRoot)/toolchains/arm-linux-androideabi-4.8/prebuilt/$(PlatformOS)-x86_64"
 +<linkflags>--sysroot=$(AndroidNDKRoot)/platforms/android-9/arch-arm
  # @Moss - Above are the 'oficial' android flags
  <architecture>arm

--- a/Build_android/boost-for-android.patch
+++ b/Build_android/boost-for-android.patch
@@ -13,29 +13,17 @@ index 40453f7..ad78ddf 100755
 +		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 +		TOOLSET=clang-androidR8e
 +                ;;
-+	"10e-rc4 (64-bit)")
++	"10e-rc4 (64-bit)"|"10e (64-bit)")
 +		TOOLCHAIN=llvm-3.6
 +		CXXPATH=$AndroidNDKRoot/toolchains/${TOOLCHAIN}/prebuilt/${PlatformOS}-x86_64/bin/clang++
 +		TOOLSET=clang-androidR8e
                  ;;
  	*)
  		echo "Undefined or not supported Android NDK version!"
-@@ -392,6 +397,7 @@ echo "Building boost for android"
-   export PATH=$AndroidBinariesPath:$PATH
-   export AndroidNDKRoot
-   export NO_BZIP2=1
-+  export ICONV_PATH="`pwd`/../../libiconv/armeabi-v7a"
- 
-   cxxflags=""
-   for flag in $CXXFLAGS; do cxxflags="$cxxflags cxxflags=$flag"; done
-@@ -404,8 +410,12 @@ echo "Building boost for android"
+@@ -404,8 +409,8 @@ echo "Building boost for android"
           threading=multi              \
           --layout=versioned           \
           --prefix="./../$BUILD_DIR/"  \
-+         boost.locale.posix=off       \
-+         boost.locale.std=on          \
-+         boost.locale.iconv=on        \
-+         boost.locale.icu=off         \
           $LIBRARIES                   \
 -         install 2>&1                 \
 +         release debug install 2>&1   \

--- a/Build_android/configure.sh
+++ b/Build_android/configure.sh
@@ -34,17 +34,15 @@ set -e
 # Parse args
 # -----------------
 
-DO_LIBICONV=1
 DO_BOOST=1
 DO_OPENSSL=1
 DO_CPPRESTSDK=1
 
 function usage {
-    echo "Usage: $0 [--skip-boost] [--skip-openssl] [--skip-libiconv] [--skip-cpprestsdk] [-h] [--ndk <android-ndk>]"
+    echo "Usage: $0 [--skip-boost] [--skip-openssl] [--skip-cpprestsdk] [-h] [--ndk <android-ndk>]"
     echo ""
     echo "    --skip-boost          Skip fetching and compiling boost"
     echo "    --skip-openssl        Skip fetching and compiling openssl"
-    echo "    --skip-libiconv       Skip fetching and compiling libiconv"
     echo "    --skip-cpprestsdk     Skip compiling cpprestsdk"
     echo "    -h,--help,-?          Display this information"
     echo "    --ndk <android-ndk>   If specified, overrides the ANDROID_NDK environment variable"
@@ -58,9 +56,6 @@ do
 	    ;;
 	"--skip-openssl")
 	    DO_OPENSSL=0
-	    ;;
-	"--skip-libiconv")
-	    DO_LIBICONV=0
 	    ;;
 	"--skip-cpprestsdk")
 	    DO_CPPRESTSDK=0
@@ -131,40 +126,6 @@ then
 )
 fi
 
-# --------
-# libiconv
-# --------
-
-# This steps are based on the blog post
-# http://danilogiulianelli.blogspot.com/2012/12/how-to-cross-compile-libiconv-for.html
-if [ "${DO_LIBICONV}" == "1" ]
-then
-(
-    if [ ! -e "libiconv-1.13.1.tar.gz" ]
-    then
-	wget http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz
-    fi
-    rm -rf libiconv
-    mkdir libiconv
-    cd libiconv
-    tar xzf ../libiconv-1.13.1.tar.gz
-    patch -b -p0 < "$DIR/libiconv/libiconv.patch"
-    cd libiconv-1.13.1
-    ./configure
-    cp -r "$DIR/libiconv/jni" ..
-    cd ../jni
-    "${NDK_DIR}/ndk-build" || exit 1
-    cd ..
-    mkdir -p armeabi-v7a/include
-    mkdir -p armeabi-v7a/lib
-    mkdir -p x86/include
-    mkdir -p x86/lib
-    cp libiconv-1.13.1/include/iconv.h armeabi-v7a/include/
-    cp libiconv-1.13.1/include/iconv.h x86/include/
-    cp obj/local/x86/libiconv.a x86/lib/
-    cp obj/local/armeabi-v7a/libiconv.a armeabi-v7a/lib/
-)
-fi
 
 # -----
 # Boost
@@ -187,7 +148,8 @@ then
 	    git apply "$DIR/boost-for-android.patch"
 	    touch cpprestsdk.patched.stamp
 	fi
-	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=locale,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
+
+	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
     )
 
     (
@@ -204,7 +166,8 @@ then
 	    ln -s ../Boost-for-Android/boost_1_55_0.tar.bz2 .
 	    touch cpprestsdk.patched.stamp
 	fi
-	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=locale,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
+
+	PATH="$PATH:$NDK_DIR" ./build-android.sh --boost=1.55.0 --with-libraries=atomic,random,date_time,filesystem,system,thread,chrono "${NDK_DIR}" || exit 1
     )
 )
 fi

--- a/Build_android/openssl/Makefile
+++ b/Build_android/openssl/Makefile
@@ -16,8 +16,8 @@ setenv-android.sh:
 
 setenv-android-x86.sh: setenv-android.sh
 	cp setenv-android.sh setenv-android-x86.sh.tmp
-	sed -i 's/_ANDROID_EABI="arm-linux-androideabi-4.8"/_ANDROID_EABI="x86-4.8"/g' setenv-android-x86.sh.tmp
-	sed -i 's/_ANDROID_ARCH=arch-arm/_ANDROID_ARCH=arch-x86/g' setenv-android-x86.sh.tmp
+	sed -i -e 's/_ANDROID_EABI="arm-linux-androideabi-4.8"/_ANDROID_EABI="x86-4.8"/g' setenv-android-x86.sh.tmp
+	sed -i -e 's/_ANDROID_ARCH=arch-arm/_ANDROID_ARCH=arch-x86/g' setenv-android-x86.sh.tmp
 	mv setenv-android-x86.sh.tmp setenv-android-x86.sh
 
 $(OPENSSL_VER).tar.gz:


### PR DESCRIPTION
The build no longer uses libiconv but there were traces left. Also boost patch had a typo for x86. With these changes, the build script should work as expected.

Fixes #85 