### PR TITLE
returning std::move causing build failure on osx

### DIFF
--- a/Release/src/http/common/http_helpers.cpp
+++ b/Release/src/http/common/http_helpers.cpp
@@ -272,7 +272,7 @@ utf16string convert_utf16_to_utf16(utf16string src)
     {
     case little_endian:
         src.erase(0, 1);
-        return std::move(src);
+        return src;
     case big_endian:
         return convert_utf16be_to_utf16le(std::move(src), true);
     case unknown:
@@ -313,7 +313,7 @@ static utf16string big_endian_to_little_endian(utf16string src, bool erase_bom)
     }
     if (src.empty())
     {
-        return std::move(src);
+        return src;
     }
 
     const size_t size = src.size();
@@ -324,7 +324,7 @@ static utf16string big_endian_to_little_endian(utf16string src, bool erase_bom)
         src[i] = static_cast<utf16char>(src[i] | ch >> 8);
     }
 
-    return std::move(src);
+    return src;
 }
 
 utility::string_t convert_utf16be_to_string_t(utf16string src, bool erase_bom)

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -486,13 +486,13 @@ utility::string_t __cdecl conversions::to_string_t(const std::string &s)
 #endif
 }
 
-std::string __cdecl conversions::to_utf8string(std::string value) { return std::move(value); }
+std::string __cdecl conversions::to_utf8string(std::string value) { return value; }
 
 std::string __cdecl conversions::to_utf8string(const utf16string &value) { return utf16_to_utf8(value); }
 
 utf16string __cdecl conversions::to_utf16string(const std::string &value) { return utf8_to_utf16(value); }
 
-utf16string __cdecl conversions::to_utf16string(utf16string value) { return std::move(value); }
+utf16string __cdecl conversions::to_utf16string(utf16string value) { return value; }
 
 #ifndef WIN32
 datetime datetime::timeval_to_datetime(const timeval &time)


### PR DESCRIPTION
build failed with clang on osx: 

```
clang --version
Apple LLVM version 7.3.0 (clang-703.0.29)
Target: x86_64-apple-darwin15.4.0
Thread model: posix
InstalledDir:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

6 tests failed, unable to test against master:

```
**** outside_tests:outside_google_dot_com FAILED ****

**** outside_tests:multiple_https_requests FAILED ****

**** outside_tests:reading_google_stream FAILED ****

**** outside_tests:server_hostname_mismatch FAILED ****

**** outside_tests:outside_ssl_json FAILED ****

**** authentication_tests:hostname_mismatch FAILED ****

Finished running all 777 tests.
Took 220217ms
```