### PR TITLE
Fix ambiguous reference to ‘credentials’

### DIFF
--- a/Release/tests/functional/http/client/proxy_tests.cpp
+++ b/Release/tests/functional/http/client/proxy_tests.cpp
@@ -97,7 +97,7 @@ TEST_FIXTURE(uri_address, no_proxy_options_on_winrt)
     web_proxy proxy(u);
     VERIFY_IS_TRUE(proxy.is_specified());
     VERIFY_ARE_EQUAL(u, proxy.address());
-    credentials cred(U("artur"), U("fred")); // relax, this is not my real password
+    web::credentials cred(U("artur"), U("fred")); // relax, this is not my real password
     proxy.set_credentials(cred);
 
     http_client_config config;


### PR DESCRIPTION
Allows compilation on Linux with GCC v5.3