### PR TITLE
Some perf improvements for uri related code

### DIFF
--- a/Release/include/cpprest/base_uri.h
+++ b/Release/include/cpprest/base_uri.h
@@ -227,7 +227,7 @@ namespace web {
         /// Creates a URI from the given URI components.
         /// </summary>
         /// <param name="components">A URI components object to create the URI instance.</param>
-        _ASYNCRTIMP uri(const details::uri_components &components) : m_components(components) { m_uri = m_components.join(); }
+        _ASYNCRTIMP uri(const details::uri_components &components);
 
         /// <summary>
         /// Creates a URI from the given encoded string. This will throw an exception if the string

--- a/Release/include/cpprest/http_headers.h
+++ b/Release/include/cpprest/http_headers.h
@@ -159,7 +159,7 @@ public:
     {
         if (has(name))
         {
-            m_headers[name] =  m_headers[name].append(_XPLATSTR(", ")).append(utility::conversions::print_string(value));
+            m_headers[name].append(_XPLATSTR(", ")).append(utility::conversions::print_string(value));
         }
         else
         {

--- a/Release/include/cpprest/uri_builder.h
+++ b/Release/include/cpprest/uri_builder.h
@@ -238,7 +238,7 @@ namespace web
         uri_builder &append_query(const utility::string_t &name, const T &value, bool do_encoding = true)
         {
             auto encodedName = name;
-            auto encodedValue = ::utility::conversions::print_string(value);
+            auto encodedValue = ::utility::conversions::print_string(value, std::locale::classic());
 
             if (do_encoding)
             {

--- a/Release/src/uri/uri.cpp
+++ b/Release/src/uri/uri.cpp
@@ -73,7 +73,7 @@ utility::string_t uri_components::join()
 
         if (m_port > 0)
         {
-            ret.append({ _XPLATSTR(':') }).append(utility::conversions::print_string(m_port));
+            ret.append({ _XPLATSTR(':') }).append(utility::conversions::print_string(m_port, std::locale::classic()));
         }
     }
 
@@ -103,6 +103,15 @@ utility::string_t uri_components::join()
 }
 
 using namespace details;
+
+uri::uri(const details::uri_components &components) : m_components(components)
+{
+    m_uri = m_components.join();
+    if (!details::uri_parser::validate(m_uri))
+    {
+        throw uri_exception("provided uri is invalid: " + utility::conversions::to_utf8string(m_uri));
+    }
+}
 
 uri::uri(const utility::string_t &uri_string)
 {

--- a/cpprestsdk140.sln
+++ b/cpprestsdk140.sln
@@ -43,20 +43,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SearchFile140", "Release\sa
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpprestsdk140.android", "Release\src\build\vs14.android\casablanca140.android.vcxproj", "{AFB49019-965B-4C10-BAFF-C86C16D58010}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpprestsdk140.wod", "Release\src\build\vs14.wod\casablanca140.wod.vcxproj", "{3A584D9C-1A98-4046-B7D3-B7171EF42D34}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpprestsdk140.uwp", "Release\src\build\vs14.uwp\cpprestsdk140.uwp.vcxproj", "{36D79E79-7E9E-4B3A-88A3-9F9B295C80B9}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpprestsdk140.uwp.staticlib", "Release\src\build\vs14.uwp\cpprestsdk140.uwp.staticlib.vcxproj", "{47A5CFDC-C244-45A6-9830-38CB303CB495}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestRunner.android.NativeActivity", "Release\tests\common\TestRunner\vs14.android\TestRunner.android.NativeActivity\TestRunner.android.NativeActivity.vcxproj", "{D1060D0A-A10E-444D-9F6B-9676EA453F9A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpprestsdk140.static", "Release\src\build\vs14.static\casablanca140.static.vcxproj", "{79C9BBEC-D7C9-4BA3-B2B3-5C3A14A9F24A}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Release\src\build\win32.vcxitems*{3a584d9c-1a98-4046-b7d3-b7171ef42d34}*SharedItemsImports = 4
-		Release\src\build\common.vcxitems*{3a584d9c-1a98-4046-b7d3-b7171ef42d34}*SharedItemsImports = 4
 		Release\src\build\winrt.vcxitems*{0a9ba181-7876-4b3d-a5e0-ee673fa51c05}*SharedItemsImports = 9
 		Release\src\build\android.vcxitems*{65951c40-a332-4b54-89c2-7cdaf30d5f66}*SharedItemsImports = 9
 		Release\src\build\winrt.vcxitems*{47a5cfdc-c244-45a6-9830-38cb303cb495}*SharedItemsImports = 4
@@ -182,22 +176,6 @@ Global
 		{AFB49019-965B-4C10-BAFF-C86C16D58010}.Release|x64.ActiveCfg = Release|x86
 		{AFB49019-965B-4C10-BAFF-C86C16D58010}.Release|x86.ActiveCfg = Release|x86
 		{AFB49019-965B-4C10-BAFF-C86C16D58010}.Release|x86.Build.0 = Release|x86
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|ARM.ActiveCfg = Debug|ARM
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|ARM.Build.0 = Debug|ARM
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|Win32.ActiveCfg = Debug|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|Win32.Build.0 = Debug|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|x64.ActiveCfg = Debug|x64
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|x64.Build.0 = Debug|x64
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|x86.ActiveCfg = Debug|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Debug|x86.Build.0 = Debug|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|ARM.ActiveCfg = Release|ARM
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|ARM.Build.0 = Release|ARM
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|Win32.ActiveCfg = Release|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|Win32.Build.0 = Release|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|x64.ActiveCfg = Release|x64
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|x64.Build.0 = Release|x64
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|x86.ActiveCfg = Release|Win32
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34}.Release|x86.Build.0 = Release|Win32
 		{36D79E79-7E9E-4B3A-88A3-9F9B295C80B9}.Debug|ARM.ActiveCfg = Debug|ARM
 		{36D79E79-7E9E-4B3A-88A3-9F9B295C80B9}.Debug|ARM.Build.0 = Debug|ARM
 		{36D79E79-7E9E-4B3A-88A3-9F9B295C80B9}.Debug|Win32.ActiveCfg = Debug|Win32
@@ -230,20 +208,6 @@ Global
 		{47A5CFDC-C244-45A6-9830-38CB303CB495}.Release|x64.Build.0 = Release|x64
 		{47A5CFDC-C244-45A6-9830-38CB303CB495}.Release|x86.ActiveCfg = Release|Win32
 		{47A5CFDC-C244-45A6-9830-38CB303CB495}.Release|x86.Build.0 = Release|Win32
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|ARM.ActiveCfg = Debug|ARM
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|ARM.Build.0 = Debug|ARM
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|Win32.ActiveCfg = Debug|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|Win32.Build.0 = Debug|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|x64.ActiveCfg = Debug|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|x86.ActiveCfg = Debug|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Debug|x86.Build.0 = Debug|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|ARM.ActiveCfg = Release|ARM
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|ARM.Build.0 = Release|ARM
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|Win32.ActiveCfg = Release|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|Win32.Build.0 = Release|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|x64.ActiveCfg = Release|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|x86.ActiveCfg = Release|x86
-		{D1060D0A-A10E-444D-9F6B-9676EA453F9A}.Release|x86.Build.0 = Release|x86
 		{79C9BBEC-D7C9-4BA3-B2B3-5C3A14A9F24A}.Debug|ARM.ActiveCfg = Debug|ARM
 		{79C9BBEC-D7C9-4BA3-B2B3-5C3A14A9F24A}.Debug|ARM.Build.0 = Debug|ARM
 		{79C9BBEC-D7C9-4BA3-B2B3-5C3A14A9F24A}.Debug|Win32.ActiveCfg = Debug|Win32
@@ -283,7 +247,6 @@ Global
 		{FFBFD6C1-B525-4D35-AB64-A2FE9460B147} = {76FA5645-FF99-44C0-87DB-B96AFAC2F800}
 		{F03BEE03-BEFB-4B17-A774-D9C8246530D4} = {22309B46-EE6F-45D0-A993-2F45D98DEF22}
 		{AFB49019-965B-4C10-BAFF-C86C16D58010} = {64F2F240-04BE-43B2-97BE-DA47FDFE8393}
-		{3A584D9C-1A98-4046-B7D3-B7171EF42D34} = {64F2F240-04BE-43B2-97BE-DA47FDFE8393}
 		{36D79E79-7E9E-4B3A-88A3-9F9B295C80B9} = {64F2F240-04BE-43B2-97BE-DA47FDFE8393}
 		{47A5CFDC-C244-45A6-9830-38CB303CB495} = {64F2F240-04BE-43B2-97BE-DA47FDFE8393}
 		{79C9BBEC-D7C9-4BA3-B2B3-5C3A14A9F24A} = {64F2F240-04BE-43B2-97BE-DA47FDFE8393}


### PR DESCRIPTION
- added overloaded function of print_string and scan_string to have string type specialized.
- added overloaded uri constructor to allow building from uri_components directly, which can save one pass of uri parsing.
- reduced the use of std::locale::classic(), which cost much CPU in thread synchronization, in places where only US-ASCII is involved.
- replace stringstream with string::append, as stringstream is notably slow in concatenating just plain strings because it has a big overhead of formatting which is designed for concatenating heterogeneous objects.