### PR TITLE
Header parsing assumes whitespace after colon

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1123,6 +1123,7 @@ private:
             if (colon != std::string::npos)
             {
                 auto name = header.substr(0, colon);
+                auto value = header.substr(colon + 1, header.size() - colon - 2);
                 boost::algorithm::trim(name);
                 boost::algorithm::trim(value);
 

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1123,7 +1123,6 @@ private:
             if (colon != std::string::npos)
             {
                 auto name = header.substr(0, colon);
-                auto value = header.substr(colon + 2, header.size() - (colon + 3)); // also exclude '\r'
                 boost::algorithm::trim(name);
                 boost::algorithm::trim(value);
 


### PR DESCRIPTION
RFC7230 (HTTP 1.1) 3.2 "Header fields" specifies that whitespace between colon and value is optional, but **http_client_asio::read_headers** started reading the value at one after the colon, assuming there would always be exactly one space.

For an HTTP server that doesn't add whitespace between colon and value, cpprestsdk reads an incorrect value and can read a truncated response, or try to read one that is 2^64 in the case where Content-Length has a single digit value.

## Examples:
_Content-Length:6_
- value  is read as an empty string and interpreted as content of 2^64 in length.

_Content-Length:26_
- value  is read as 6 and truncated response is read.
