### PR TITLE
Making oauth2_config::_request_token protected

### DIFF
--- a/Release/include/cpprest/oauth2.h
+++ b/Release/include/cpprest/oauth2.h
@@ -466,6 +466,9 @@ public:
 		m_proxy = proxy;
 	}
 
+protected:
+	_ASYNCRTIMP pplx::task<void> _request_token(uri_builder& request_body);
+
 private:
     friend class web::http::client::http_client_config;
     friend class web::http::oauth2::details::oauth2_handler;
@@ -475,8 +478,6 @@ private:
         m_bearer_auth(true),
         m_http_basic_auth(true)
     {}
-
-    _ASYNCRTIMP pplx::task<void> _request_token(uri_builder& request_body);
 
     oauth2_token _parse_token_from_json(const json::value& token_json);
 


### PR DESCRIPTION
To allow library users to subclass oauth2_config to implement custom oauth extensions
