### PR TITLE
remove warnings-errors for system-headers under linux; honour http_proxy env-variable

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -149,7 +149,7 @@ if(ANDROID)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes -Wno-pointer-arith")
-  include_directories(
+  include_directories(SYSTEM
     "${ANDROID_NDK}/sources/cxx-stl/gnu-libstdc++/4.8/include"
     "${ANDROID_NDK}/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include"
     "${ANDROID_NDK}/sources/cxx-stl/gnu-libstdc++/4.8/include/backward"
@@ -197,7 +197,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Binaries)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Binaries)
 
 # These settings can be used by the test targets
-set(Casablanca_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(Casablanca_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
 if (NOT CPPREST_EXCLUDE_WEBSOCKETS)
   find_path(WEBSOCKETPP_CONFIG websocketpp-config.cmake
                         HINTS /usr/lib/cmake/websocketpp)
@@ -207,20 +207,19 @@ if (NOT CPPREST_EXCLUDE_WEBSOCKETS)
     include(${WEBSOCKETPP_CONFIG}/websocketpp-config.cmake)
     include(${WEBSOCKETPP_CONFIG}/websocketpp-configVersion.cmake)
     message("-- Found websocketpp version " ${PACKAGE_VERSION} " on system")
-    set(Casablanca_INCLUDE_DIRS ${Casablanca_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${WEBSOCKETPP_INCLUDE_DIR})
+    set(Casablanca_SYSTEM_INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${WEBSOCKETPP_INCLUDE_DIR})
   else(WEBSOCKETPP_CONFIG AND WEBSOCKETPP_CONFIG_VERSION)
-    set(Casablanca_INCLUDE_DIRS ${Casablanca_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp)
+    set(Casablanca_SYSTEM_INCLUDE_DIRS ${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp)
     message("-- websocketpp not found, using the embedded version")
   endif(WEBSOCKETPP_CONFIG AND WEBSOCKETPP_CONFIG_VERSION)
-else()
-  set(Casablanca_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
 endif()
 
 set(Casablanca_LIBRARY cpprest)
 set(Casablanca_LIBRARIES cpprest ${Boost_LIBRARIES})
 
 # Everything in the project needs access to the casablanca include directories
-include_directories(${Casablanca_INCLUDE_DIRS})
+include_directories(       ${Casablanca_INCLUDE_DIRS})
+include_directories(SYSTEM ${Casablanca_SYSTEM_INCLUDE_DIRS})
 
 # Finally, the tests all use the same style declaration to build themselves, so we use a function
 function(add_casablanca_test NAME SOURCES_VAR)

--- a/Release/libs/websocketpp/CMakeLists.txt
+++ b/Release/libs/websocketpp/CMakeLists.txt
@@ -190,7 +190,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
 
     if (Boost_FOUND)
         # Boost is a project wide global dependency.
-        include_directories (${Boost_INCLUDE_DIRS})
+        include_directories (SYSTEM ${Boost_INCLUDE_DIRS})
         link_directories (${Boost_LIBRARY_DIRS})
 
         # Pretty print status

--- a/Release/samples/BingRequest/bingrequest.cpp
+++ b/Release/samples/BingRequest/bingrequest.cpp
@@ -30,6 +30,23 @@ using namespace web::http;
 using namespace web::http::client;
 using namespace concurrency::streams;
 
+/* Can pass proxy information via environment variable http_proxy.
+   Example:
+   Linux:   export http_proxy=http://192.1.8.1:8080
+ */
+web::http::client::http_client_config client_config_for_proxy()
+{
+    web::http::client::http_client_config client_config;
+
+    if(const char* env_http_proxy = std::getenv("http_proxy")) {
+        web::web_proxy proxy(env_http_proxy);
+        client_config.set_proxy(proxy);
+    }
+
+    return client_config;
+}
+
+
 #ifdef _WIN32
 int wmain(int argc, wchar_t *args[])
 #else
@@ -52,7 +69,7 @@ int main(int argc, char *args[])
 
         // Create an HTTP request.
         // Encode the URI query since it could contain special characters like spaces.
-        http_client client(U("http://www.bing.com/"));
+        http_client client(U("http://www.bing.com/"), client_config_for_proxy());
         return client.request(methods::GET, uri_builder(U("/search")).append_query(U("q"), searchTerm).to_string());
     })
 

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(../include pch)
 if (NOT CPPREST_EXCLUDE_WEBSOCKETS)
-  include_directories(${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
+  include_directories(SYSTEM ${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 endif()
 
 add_definitions(${WARNINGS})


### PR DESCRIPTION
## remove warnings-errors for system-headers under linux

I'm compiling on Debian GNU/Linux using my own boost, calling cmake like this
```bash
cmake -DBOOST_ROOT=~/boost_own/boost_1_61_0/  ../Release/
```

The **build fails** with `Werror` errors when parsing through **system**-headers; basically stuff such as
```
/home/dude/boost_own/boost_1_61_0/include/boost/asio/detail/impl/eventfd_select_interrupter.ipp:122:69: error: conversion to ‘int’ from ‘ssize_t {aka long int}’ may alter its value [-Werror=conversion]
```

**Fix**

Use this in `CmakeLists.txt`
```cmake
include_directories (SYSTEM ${Boost_INCLUDE_DIRS})
#                    ^^^^^^
```

## honour http_proxy env-variable

Implemented in BingRequest.  
If you're behind a proxy you can now do:
```bash
export http_proxy=http://192.1.8.1:8080
./BingRequest "my search terms" out.html
```

_____________________________________________________________________________

This pull-request is for you development branch. (If you like this stuff in master, I have a branch called `master_headers_proxy` as well.)