### PR TITLE
ifndef BOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION

### DIFF
--- a/Release/include/cpprest/details/cpprest_compat.h
+++ b/Release/include/cpprest/details/cpprest_compat.h
@@ -68,7 +68,9 @@
 // without this macro defined, it will create references to __tls_get_addr
 // which (while able to link) will not be available at runtime and prevent
 // the .so from loading.
+#if not defined BOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION
 #define BOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION
+#endif
 #endif
 
 #ifdef __clang__


### PR DESCRIPTION
This can be defined elsewhere and can raise an error.