### PR TITLE
Adding PARENT_SCOPE

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -197,7 +197,7 @@ set(Casablanca_LIBRARIES ${Casablanca_LIBRARY}
   ${Boost_CHRONO_LIBRARY}
   ${Boost_RANDOM_LIBRARY}
   ${Boost_REGEX_LIBRARY}
-  ${Boost_FRAMEWORK})
+  ${Boost_FRAMEWORK} PARENT_SCOPE)
 
 # Everything in the project needs access to the casablanca include directories
 include_directories(${Casablanca_INCLUDE_DIRS})


### PR DESCRIPTION
To make it possible to include as sub-project from external projects. This lets the variable `Casablanca_LIBRARIES` be accessible from the parent project