### PR TITLE
Allow const access operator for json objects and arrays

### DIFF
--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -220,6 +220,12 @@ namespace json
         /// <returns>The JSON value object that contains the result of the assignment.</returns>
         _ASYNCRTIMP value &operator=(value &&) CPPREST_NOEXCEPT ;
 
+        /// <summary>
+        /// Returns the static immutable null reference
+        /// </summary>
+        /// <returns>A static null reference</returns>
+        static _ASYNCRTIMP const value& __cdecl null_ref();
+
         // Static factories
 
         /// <summary>
@@ -611,6 +617,13 @@ public:
         /// <returns>A reference to the value kept in the field.</returns>
         _ASYNCRTIMP value & operator [] (const utility::string_t &key);
 
+        /// <summary>
+        /// Accesses a field of a JSON object.
+        /// </summary>
+        /// <param name="key">The name of the field</param>
+        /// <returns>A reference to the value kept in the field or the null reference.</returns>
+        _ASYNCRTIMP const value & operator [] (const utility::string_t &key) const;
+
 #ifdef _WIN32
 private:
         // Only used internally by JSON parser
@@ -636,6 +649,13 @@ public:
         /// <param name="index">The index of an element in the JSON array.</param>
         /// <returns>A reference to the value kept in the field.</returns>
         _ASYNCRTIMP value & operator [] (size_t index);
+
+        /// <summary>
+        /// Accesses an element of a JSON array.
+        /// </summary>
+        /// <param name="index">The index of an element in the JSON array.</param>
+        /// <returns>A reference to the value kept in the field or the null reference.</returns>
+        _ASYNCRTIMP const value & operator [] (size_t index) const;
 
     private:
         friend class web::json::details::_Object;
@@ -941,6 +961,22 @@ public:
         }
 
         /// <summary>
+        /// Accesses an element of a JSON array.
+        /// </summary>
+        /// <param name="index">The index of an element in the JSON array.</param>
+        /// <returns>A reference to the value kept in the field or the null reference.</returns>
+        const json::value& operator[](size_type index) const
+        {
+            msl::safeint3::SafeInt<size_type> nMinSize(index);
+            nMinSize += 1;
+            msl::safeint3::SafeInt<size_type> nlastSize(m_elements.size());
+            if (nlastSize < nMinSize)
+                return json::value::null_ref();
+
+            return m_elements[index];
+        }
+
+        /// <summary>
         /// Gets the number of elements of the array.
         /// </summary>
         /// <returns>The number of elements.</returns>
@@ -1158,6 +1194,23 @@ public:
             if (iter == m_elements.end() || key != iter->first)
             {
                 return m_elements.insert(iter, std::pair<utility::string_t, value>(key, value()))->second;
+            }
+
+            return iter->second;
+        }
+
+        /// <summary>
+        /// Accesses an element of a JSON object.
+        /// </summary>
+        /// <param name="key">The key of an element in the JSON object.</param>
+        /// <returns>If the key exists, a reference to the value kept in the field, or the null reference.</returns>
+        const json::value& operator[](const utility::string_t& key) const
+        {
+            auto iter = find(key);
+
+            if (iter == m_elements.end())
+            {
+                return json::value::null_ref();
             }
 
             return iter->second;
@@ -1679,6 +1732,8 @@ public:
 
             virtual json::value &index(const utility::string_t &key);
 
+            virtual const json::value &cnst_index(const utility::string_t &key) const;
+
             bool is_equal(const _Object* other) const
             {
                 if (m_object.size() != other->m_object.size())
@@ -1786,6 +1841,11 @@ public:
             virtual const json::array& as_array() const { return m_array; }
 
             virtual json::value &index(json::array::size_type index)
+            {
+                return m_array[index];
+            }
+
+            virtual const json::value &cnst_index(json::array::size_type index) const
             {
                 return m_array[index];
             }

--- a/Release/src/json/json.cpp
+++ b/Release/src/json/json.cpp
@@ -160,6 +160,12 @@ web::json::value &web::json::value::operator=(web::json::value &&other) CPPREST_
     return *this;
 }
 
+const web::json::value& web::json::value::null_ref()
+{
+    static web::json::value null_val;
+    return null_val;
+}
+
 web::json::value web::json::value::null()
 {
     return web::json::value();
@@ -389,6 +395,11 @@ json::value& web::json::details::_Object::index(const utility::string_t &key)
     return m_object[key];
 }
 
+const json::value& web::json::details::_Object::cnst_index(const utility::string_t &key) const
+{
+    return m_object[key];
+}
+
 bool web::json::details::_Object::has_field(const utility::string_t &key) const
 {
     return m_object.find(key) != m_object.end();
@@ -470,6 +481,15 @@ web::json::value& web::json::value::operator [] (const utility::string_t &key)
     return m_value->index(key);
 }
 
+const web::json::value& web::json::value::operator [] (const utility::string_t &key) const
+{
+    if ( this->is_object() )
+    {
+        return m_value->cnst_index(key);
+    }
+    return null_ref();
+}
+
 web::json::value& web::json::value::operator[](size_t index)
 {
     if ( this->is_null() )
@@ -480,6 +500,15 @@ web::json::value& web::json::value::operator[](size_t index)
 #endif
     }
     return m_value->index(index);
+}
+
+const web::json::value& web::json::value::operator[](size_t index) const
+{
+    if ( this->is_array() )
+    {
+        return m_value->cnst_index(index);
+    }
+    return null_ref();
 }
 
 // Remove once VS 2013 is no longer supported.


### PR DESCRIPTION
Const access operators would shorten some conditional checks.

For example:

```C++
void some_function(const web::json::value& obj)
{
    if (obj.has_field("someField") && obj.at("someField").is_string()) {
        // do something
    }
}
```
Would become:
```C++
void some_function(const web::json::value& obj)
{
    if (obj["someField"].is_string()) {
        // do something
    }
}
```

Also readable chaining:
```C++
void some_other_function(const web::json::value& obj)
{
    if (obj["someObject"]["someNestedObject"]["someField"].is_string()) {
        // do something
    }
}
```