### PR TITLE
Fix namespace issue with proxy_tests

### DIFF
--- a/Release/tests/functional/http/client/proxy_tests.cpp
+++ b/Release/tests/functional/http/client/proxy_tests.cpp
@@ -97,7 +97,8 @@ TEST_FIXTURE(uri_address, no_proxy_options_on_winrt)
     web_proxy proxy(u);
     VERIFY_IS_TRUE(proxy.is_specified());
     VERIFY_ARE_EQUAL(u, proxy.address());
-    credentials cred(U("artur"), U("fred")); // relax, this is not my real password
+    // Explicit web:: namespace because krb5 also defines a credentials struct
+    web::credentials cred(U("artur"), U("fred")); // relax, this is not my real password
     proxy.set_credentials(cred);
 
     http_client_config config;


### PR DESCRIPTION
credentials with no namespace is ambiguous when built on Fedora with
krb5 things installed. Being explicit that we want web::credentials here
and not the credentials struct from krb5.h solves the issue.