### PR TITLE
Enable TLS 1.1 and 1.2

### DIFF
--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -427,6 +427,14 @@ protected:
             }
         }
 #endif
+		//Enable TLS 1.1 and 1.2
+		HRESULT result(S_OK);
+		BOOL win32_result(FALSE);
+
+		DWORD secure_protocols(WINHTTP_FLAG_SECURE_PROTOCOL_SSL3|WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_1 | WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2);
+		win32_result = ::WinHttpSetOption(m_hSession, WINHTTP_OPTION_SECURE_PROTOCOLS, &secure_protocols, sizeof(secure_protocols));
+		if(FALSE == win32_result){ result = HRESULT_FROM_WIN32(::GetLastError()); }
+
         // Register asynchronous callback.
         if(WINHTTP_INVALID_STATUS_CALLBACK == WinHttpSetStatusCallback(
             m_hSession,


### PR DESCRIPTION
Enable tls 1.1 and 1.2 … 

By default only SSL3 and TLS1 are enabled in Windows 7 and Windows 8.
By default only SSL3, TLS1.0, TLS1.1, and TLS1.2 are enabled in Windows 8.1 and Windows 10.

https://msdn.microsoft.com/en-us/library/windows/desktop/aa384066