### PR TITLE
bug fix : m_close initialization in wrong place

### DIFF
--- a/Release/include/cpprest/details/http_server_asio.h
+++ b/Release/include/cpprest/details/http_server_asio.h
@@ -82,6 +82,7 @@ public:
     , m_response_buf()
     , m_p_server(server)
     , m_p_parent(parent)
+    , m_close(false)
     , m_refs(1)
     {
         if (is_https)

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -362,7 +362,7 @@ void connection::handle_headers()
         }
     }
 
-    m_close = m_chunked = false;
+    m_chunked = false;
     utility::string_t name;
     // check if the client has requested we close the connection
     if (m_request.headers().match(header_names::connection, name))

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -258,6 +258,11 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request._reply_if_not_already(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
+            return;
         }
     }
     else
@@ -285,6 +290,10 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request.reply(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
 
@@ -300,6 +309,10 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request.reply(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
 
@@ -313,6 +326,10 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request.reply(status_codes::BadRequest, e.what());
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
 
@@ -358,6 +375,10 @@ void connection::handle_headers()
             m_request.reply(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
     }


### PR DESCRIPTION
m_close getting initialised in handle_headers wipes out the value assigned to it in handle_http_line.
This could cause some connection objects to not get released, for example if the request is HTTP1.0.

@ras0219-msft
