### PR TITLE
ECONNRESET must be used instead of ECONNABORTED.

### DIFF
--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -249,7 +249,12 @@ void connection::handle_http_line(const boost::system::error_code& ec)
     if (ec)
     {
         // client closed connection
-        if (ec == boost::asio::error::eof || ec == boost::asio::error::operation_aborted)
+        if (
+            ec == boost::asio::error::eof ||                // peer has performed an orderly shutdown
+            ec == boost::asio::error::operation_aborted ||  // this can be removed. ECONNABORTED happens only for accept()
+            ec == boost::asio::error::connection_reset ||   // connection reset by peer
+            ec == boost::asio::error::timed_out             // connection timed out
+        )
         {
             finish_request_response();
         }


### PR DESCRIPTION
fix for bug: when client does not perform an orderly shutdown of the connection during recv() or read() the error code returned is 'connection reset by peer' or 'connection timed out' according to the open group specification (also linux specification). It is not 'operation aborted' which the current code assumes. 'operation aborted' happens during accept().
This fix was needed on RHEL 7 server.
References:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
https://linux.die.net/man/3/recv
