### PR TITLE
Adding the TARGET_INCLUDE_DIRECTORIES directive to CMakeLists.txt for…

### DIFF
--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -114,6 +114,11 @@ endif()
 
 add_library(cpprest ${SOURCES})
 
+target_include_directories(cpprest
+  INTERFACE $<INSTALL_INTERFACE:include>
+  PUBLIC    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  )
+
 target_link_libraries(cpprest
   ${CMAKE_THREAD_LIBS_INIT}
   ${Boost_SYSTEM_LIBRARY}


### PR DESCRIPTION
Adding the TARGET_INCLUDE_DIRECTORIES directive to CMakeLists.txt for a better CPPRESTSDK integration into a bigger hierarchical CMAKE-based project.

I use cpprestsdk in another CMAKE-based project and I found useful to include the TARGET_INCLUDE_DIRECTORY into your CMakeLists.txt so that when I reference cpprest with the TARGET_LINK_LIBRARIES directive it automatically add the cpprest include path. So why not adding it to your main repo too?