### PR TITLE
Enable IPv6 addresses to be resolved and specified as valid URI

### DIFF
--- a/Release/include/cpprest/details/uri_parser.h
+++ b/Release/include/cpprest/details/uri_parser.h
@@ -143,13 +143,11 @@ namespace web { namespace details
         /// - The percent character ('%'), and thus any percent-endcoded octet
         /// - The sub-delimiters
         /// - ':' (colon)
-        ///
-        /// Note that we don't currently support:
-        /// - IPv6 addresses (requires '[]')
+        /// - IPv6 requires '[]' allowed for it to be valid URI and passed to underlying platform for IPv6 support
         /// </summary>
         inline bool is_authority_character(int c)
         {
-            return is_unreserved(c) || is_sub_delim(c) || c == '%' || c == '@' || c == ':';
+            return is_unreserved(c) || is_sub_delim(c) || c == '%' || c == '@' || c == ':' || c == '[' || c == ']';
         }
 
         /// <summary>

--- a/Release/src/uri/uri_parser.cpp
+++ b/Release/src/uri/uri_parser.cpp
@@ -240,7 +240,8 @@ bool inner_parse(
         // or by EOS. The authority could be empty ('file:///C:\file_name.txt')
         for (;*p != _XPLATSTR('/') && *p != _XPLATSTR('?') && *p != _XPLATSTR('#') && *p != _XPLATSTR('\0'); p++)
         {
-            // We're NOT currently supporting IPv6, IPvFuture or username/password in authority
+            // We're NOT currently supporting IPvFuture or username/password in authority
+            // IPv6 as the host (i.e. http://[:::::::]) is allowed as valid URI and passed to subsystem for support.
             if (!is_authority_character(*p))
             {
                 return false;

--- a/Release/tests/functional/uri/constructor_tests.cpp
+++ b/Release/tests/functional/uri/constructor_tests.cpp
@@ -130,6 +130,60 @@ TEST(parsing_constructor_invalid)
     VERIFY_THROWS(uri(U("http://local\"host:345/")), uri_exception);
 }
 
+// Tests a variety of different URIs using the examples in RFC 2732
+TEST(RFC_2732_examples_string)
+{
+    // The URI parser will make characters lower case
+    uri http1(U("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"));
+    VERIFY_ARE_EQUAL(U("http"), http1.scheme());
+    VERIFY_ARE_EQUAL(U("[fedc:ba98:7654:3210:fedc:ba98:7654:3210]"), http1.host());
+    VERIFY_ARE_EQUAL(80, http1.port());
+    VERIFY_ARE_EQUAL(U("/index.html"), http1.path());
+    VERIFY_ARE_EQUAL(U(""), http1.query());
+
+    uri http2(U("http://[1080:0:0:0:8:800:200C:417A]/index.html"));
+    VERIFY_ARE_EQUAL(U("http"), http2.scheme());
+    VERIFY_ARE_EQUAL(U("[1080:0:0:0:8:800:200c:417a]"), http2.host());
+    VERIFY_ARE_EQUAL(0, http2.port());
+    VERIFY_ARE_EQUAL(U("/index.html"), http2.path());
+    VERIFY_ARE_EQUAL(U(""), http2.query());
+
+    uri http3(U("https://[3ffe:2a00:100:7031::1]"));
+    VERIFY_ARE_EQUAL(U("https"), http3.scheme());
+    VERIFY_ARE_EQUAL(U("[3ffe:2a00:100:7031::1]"), http3.host());
+    VERIFY_ARE_EQUAL(0, http3.port());
+    VERIFY_ARE_EQUAL(U("/"), http3.path());
+    VERIFY_ARE_EQUAL(U(""), http3.query());
+
+    uri http4(U("http://[::192.9.5.5]/ipng"));
+    VERIFY_ARE_EQUAL(U("http"), http4.scheme());
+    VERIFY_ARE_EQUAL(U("[::192.9.5.5]"), http4.host());
+    VERIFY_ARE_EQUAL(0, http4.port());
+    VERIFY_ARE_EQUAL(U("/ipng"), http4.path());
+    VERIFY_ARE_EQUAL(U(""), http4.query());
+
+    uri http5(U("http://[1080::8:800:200C:417A]/foo"));
+    VERIFY_ARE_EQUAL(U("http"), http5.scheme());
+    VERIFY_ARE_EQUAL(U("[1080::8:800:200c:417a]"), http5.host());
+    VERIFY_ARE_EQUAL(0, http5.port());
+    VERIFY_ARE_EQUAL(U("/foo"), http5.path());
+    VERIFY_ARE_EQUAL(U(""), http5.query());
+
+    uri http6(U("http://[::FFFF:129.144.52.38]:80/index.html"));
+    VERIFY_ARE_EQUAL(U("http"), http6.scheme());
+    VERIFY_ARE_EQUAL(U("[::ffff:129.144.52.38]"), http6.host());
+    VERIFY_ARE_EQUAL(80, http6.port());
+    VERIFY_ARE_EQUAL(U("/index.html"), http6.path());
+    VERIFY_ARE_EQUAL(U(""), http6.query());
+
+    uri http7(U("http://[2010:836B:4179::836B:4179]"));
+    VERIFY_ARE_EQUAL(U("http"), http7.scheme());
+    VERIFY_ARE_EQUAL(U("[2010:836b:4179::836b:4179]"), http7.host());
+    VERIFY_ARE_EQUAL(0, http7.port());
+    VERIFY_ARE_EQUAL(U("/"), http7.path());
+    VERIFY_ARE_EQUAL(U(""), http7.query());
+}
+
 // Tests a variety of different URIs using the examples in RFC 3986.
 TEST(RFC_3968_examples_string)
 {


### PR DESCRIPTION
An IPv6 address must be enclosed in [] when in a URI (i.e.
http://[:::::::]:80).  This change allows the '[' and ']' as characters
allowed as part of the authority so the underlying HTTP library can
receive a resolved IPv6 address and utilize.  The subsystem itself must
support utilizing, this change only allows it to be treated as valid.