### PR TITLE
Don't add default port to 'Host' header in ASIO

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -659,7 +659,11 @@ public:
             // Add the Host header if user has not specified it explicitly
             if (!ctx->m_request.headers().has(header_names::host))
             {
-                request_stream << "Host: " << host << ":" << port << CRLF;
+                request_stream << "Host: " << host;
+                if (!base_uri.is_port_default()) {
+                    request_stream << ":" << port;
+                }
+                request_stream << CRLF;
             }
                 
             // Extra request headers are constructed here.


### PR DESCRIPTION
If requesting data through a pre-signed S3 URL [1], the signature calculation includes the hostname provided in the 'Host' header. Appending the default port number - as done in `asio_context::start_request()` - invalidates this signature and prevents us from down-/uploading data through such URLs.

Since appending the port number to the 'Host' header is optional [2], we can omit it in the default case. This fixes the usage of pre-signed S3 URLs with C++ REST SDK.

A work-around for this fix is setting the 'Host' port appropriately in the `http_request` object when making a request through `http_client`.

Note that this works perfectly fine on Windows when using the *WinHTTP* backend.

[1] http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html
[2] https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23