### PR TITLE
Use 1.0.2k openssl library - Play store rejects 1.0.2d

### DIFF
--- a/Build_android/openssl/Makefile
+++ b/Build_android/openssl/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-OPENSSL_VER = openssl-1.0.2d
+OPENSSL_VER = openssl-1.0.2k
 
 all: armeabi-v7a/lib/libssl.a x86/lib/libssl.a
 


### PR DESCRIPTION
On Android we need a newer openssl library otherwise this nuget package is pretty much useless. Play store scans and somehow finds compiled 1.0.2d in binary and rejects the upload.