### PR TITLE
Handled uncaught exception when request contains bad encoded URI

### DIFF
--- a/Release/tests/functional/http/listener/request_relative_uri_tests.cpp
+++ b/Release/tests/functional/http/listener/request_relative_uri_tests.cpp
@@ -115,6 +115,27 @@ TEST(listener_uri_empty_path)
     listener.close().wait();
 }
 
+TEST(listener_invalid_encoded_uri)
+{
+    uri address(U("http://localhost:45678"));
+    http_listener listener(address);
+    listener.open().wait();
+    test_http_client::scoped_client client(address);
+    test_http_client * p_client = client.client();
+
+    listener.support([](http_request request)
+    {
+        request.reply(status_codes::OK);
+    });
+    VERIFY_ARE_EQUAL(0, p_client->request(methods::GET, U("/%invalid/uri")));
+    p_client->next_response().then([](test_response *p_response)
+    {
+        http_asserts::assert_test_response_equals(p_response, status_codes::BadRequest);
+    }).wait();
+
+    listener.close().wait();
+}
+
 }
 
 }}}}


### PR DESCRIPTION
If you launch a simple server using this SDK and make a GET on any URI, the server crashes due to an uncaught exception. I can't catch it by myself as it is thrown when the incoming request gets analyzed to choose the right handler.

I chose the BadRequest error code as it best fits the situation. I could not inspect the windows server as I do not have a windows system at hand.