### PR TITLE
test_runner needs to be linked with libdl

### DIFF
--- a/Release/tests/common/TestRunner/CMakeLists.txt
+++ b/Release/tests/common/TestRunner/CMakeLists.txt
@@ -23,6 +23,7 @@ elseif(APPLE)
     )
 elseif(UNIX)
   target_link_libraries(test_runner PRIVATE
+    dl
     -Wl,--whole-archive
     httpclient_test
     json_test


### PR DESCRIPTION
Hey,

Building cpprestsdk on Fedora, I had this issue:  Microsoft/cpprestdsk#247

This can be fixed by linking the test_runner to libdl.