### PR TITLE
Supply missing WindowsTargetPlatformVersion setting...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ Intermediate/
 # Ignore cmake building directories
 build.*/
 docs/
+# ignore NuGet artifacts
+.nuget/

--- a/Release/src/build/vs14.xp/casablanca140.xp.vcxproj
+++ b/Release/src/build/vs14.xp/casablanca140.xp.vcxproj
@@ -13,6 +13,7 @@
     <WinRTProject>false</WinRTProject>
     <TargetXP>true</TargetXP>
     <ProjectName>cpprestsdk140.xp</ProjectName>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.root))\Build\Config.Definitions.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -42,7 +43,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <TargetName>$(CppRestBaseFileName)140$(DebugFileSuffix)_xp_$(CppRestSDKVersionFileSuffix)</TargetName>
-    <NuGetPackageImportStamp>eec97f90</NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemGroup>
     <None Include="packages.config">


### PR DESCRIPTION
...that VS2017 insists be there. Add some NuGet droppings to .gitignore

Without this element in vcxproj an attempt to view project properties in VS2017 complains with a dialog that says "Value cannot be null.Parameter name: key".