### PR TITLE
Suppress Intel C++ Compiler 17.0 warning

### DIFF
--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -1383,6 +1383,7 @@ public:
                 return m_value == other.m_value;
             }
             __assume(0);
+            return false;
         }
 
     private:


### PR DESCRIPTION
Intel C++ Compiler 17.0 concerned about missing return statement at the end of function:
`cpprest\json.h(1398): warning #1011: missing return statement at end of non-void function "web::json::number::operator=="`

buf fix of #455