### PR TITLE
Added NuGet.Config.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
Building might fail in systems with non-default (overriden) NuGet configuration.

This change ensures packages are fetched to the workspace's `packages` folder.