### PR TITLE
Fixed test_runner build when BUILD_SHARED_LIBS=OFF

### DIFF
--- a/Release/tests/common/TestRunner/CMakeLists.txt
+++ b/Release/tests/common/TestRunner/CMakeLists.txt
@@ -22,7 +22,7 @@ elseif(APPLE)
     -Wl,-force_load utils_test
     )
 elseif(UNIX)
-  target_link_libraries(test_runner PRIVATE
+  target_link_libraries(test_runner PRIVATE ${CMAKE_DL_LIBS}
     -Wl,--whole-archive
     httpclient_test
     json_test


### PR DESCRIPTION
test_running always needs linking to libdl.
Found the problem when building static library on RedHat 7.