### PR TITLE
Improve http_proxy handling in BingRequest sample

### DIFF
--- a/Release/samples/BingRequest/bingrequest.cpp
+++ b/Release/samples/BingRequest/bingrequest.cpp
@@ -29,9 +29,9 @@ web::http::client::http_client_config client_config_for_proxy()
     wchar_t* pValue;
     size_t len;
     auto err = _wdupenv_s(&pValue, &len, L"http_proxy");
-    if (!err && pValue) {
+    if (!err && pValue && len) {
         std::unique_ptr<wchar_t, void(*)(wchar_t*)> holder(pValue, [](wchar_t* p) { free(p); });
-        uri proxy_uri(std::wstring(pValue, len));
+        uri proxy_uri(std::wstring(pValue, len - 1));
 #else
     if(const char* env_http_proxy = std::getenv("http_proxy")) {
         uri proxy_uri(utility::conversions::to_string_t(env_http_proxy));

--- a/Release/samples/BingRequest/bingrequest.cpp
+++ b/Release/samples/BingRequest/bingrequest.cpp
@@ -29,7 +29,7 @@ web::http::client::http_client_config client_config_for_proxy()
     wchar_t* pValue;
     size_t len;
     auto err = _wdupenv_s(&pValue, &len, L"http_proxy");
-    if (!err) {
+    if (!err && pValue) {
         std::unique_ptr<wchar_t, void(*)(wchar_t*)> holder(pValue, [](wchar_t* p) { free(p); });
         uri proxy_uri(std::wstring(pValue, len));
 #else


### PR DESCRIPTION
This PR consists of 2 somewhat independent parts (I decided it would be more convenient to have them in the same PR, but please let me know if you want me to split it in 2): first, and most importantly, the first commit fixes the sample behaviour by default as currently it just fails to open connection if `http_proxy` is not defined, so it's broken out of the box. This is especially annoying because there is no exception handling in the sample (which is IMO far from ideal, but I didn't change this because this is, perhaps, intentional to keep things simple?), so it simply crashes without any explanation as to why does it happen.

Second, the 2nd and 3rd commits allow to use `http_proxy=auto` with this sample as it's convenient for testing.