### PR TITLE
Fix unreachable statement warning from MSVC after ICC warning fix

### DIFF
--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -1383,7 +1383,12 @@ public:
                 return m_value == other.m_value;
             }
             __assume(0);
+            // Absence of this return statement provokes a warning from Intel
+            // compiler, but its presence results in a warning from MSVC, so
+            // we have to resort to conditional compilation to keep both happy.
+#ifdef __INTEL_COMPILER
             return false;
+#endif
         }
 
     private:


### PR DESCRIPTION
Adding a return statement after __assume(0) resulted in "warning C4702:
unreachable code" when building with MSVC, which broke the build as warnings
are fatal due to the use of /WX options.

Fix this by using this return statement only with the Intel compiler, which
apparently needs it (see e3f81c436f62c46899037bc8eac4f64de3a12a15).