### PR TITLE
Avoid spurious errors when handling HTTP responses without body

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1229,9 +1229,17 @@ private:
             }
         }
 
+        // Check for HEAD requests and status codes which cannot contain a
+        // message body in HTTP/1.1 (see 3.3.3/1 of the RFC 7230).
+        //
         // note: need to check for 'chunked' here as well, azure storage sends both
         // transfer-encoding:chunked and content-length:0 (although HTTP says not to)
-        if (m_request.method() == U("HEAD") || (!needChunked && m_content_length == 0))
+        const auto status = m_response.status_code();
+        if (m_request.method() == U("HEAD")
+            || (status >= 100 && status < 200)
+            || status == status_codes::NoContent
+            || status == status_codes::NotModified
+            || (!needChunked && m_content_length == 0))
         {
             // we can stop early - no body
             const auto &progress = m_request._get_impl()->_progress_handler();


### PR DESCRIPTION
There is no message body for 1xx, 203 and 304 HTTP responses (see
section 3.3.3/1 of RFC 7230), yet we tried to read it nevertheless when
using ASIO backend, resulting in "Failed to read response body"
exception being thrown.

Fix this by explicitly skipping reading the body for these status codes.

----

This is (or should be, IMO) relatively high priority as it fixes a bug which currently breaks any application receiving 304 responses (which are quite common, of course) under Linux.