### PR TITLE
Make web::uri_builder::to_string() and ::to_uri() const

### DIFF
--- a/Release/include/cpprest/uri_builder.h
+++ b/Release/include/cpprest/uri_builder.h
@@ -261,13 +261,13 @@ namespace web
         /// Combine and validate the URI components into a encoded string. An exception will be thrown if the URI is invalid.
         /// </summary>
         /// <returns>The created URI as a string.</returns>
-        _ASYNCRTIMP utility::string_t to_string();
+        _ASYNCRTIMP utility::string_t to_string() const;
 
         /// <summary>
         /// Combine and validate the URI components into a URI class instance. An exception will be thrown if the URI is invalid.
         /// </summary>
         /// <returns>The create URI as a URI class instance.</returns>
-        _ASYNCRTIMP uri to_uri();
+        _ASYNCRTIMP uri to_uri() const;
 
         /// <summary>
         /// Validate the generated URI from all existing components of this uri_builder.

--- a/Release/src/uri/uri_builder.cpp
+++ b/Release/src/uri/uri_builder.cpp
@@ -91,12 +91,12 @@ uri_builder &uri_builder::append(const http::uri &relative_uri)
     return *this;
 }
 
-utility::string_t uri_builder::to_string()
+utility::string_t uri_builder::to_string() const
 {
     return to_uri().to_string();
 }
 
-uri uri_builder::to_uri()
+uri uri_builder::to_uri() const
 {
     return uri(m_uri);
 }


### PR DESCRIPTION
There is no reason for those to be non-const. We would like to call them inside a `const` context. :)