### PR TITLE
Fix/win32 encryption throws by empty string

### DIFF
--- a/Release/src/utilities/web_utilities.cpp
+++ b/Release/src/utilities/web_utilities.cpp
@@ -92,6 +92,7 @@ plaintext_string winrt_encryption::decrypt() const
 win32_encryption::win32_encryption(const std::wstring &data) :
     m_numCharacters(data.size())
 {
+    // Early return because CryptProtectMemory crashs with empty string
     if (m_numCharacters == 0)
     {
         return;

--- a/Release/src/utilities/web_utilities.cpp
+++ b/Release/src/utilities/web_utilities.cpp
@@ -92,6 +92,11 @@ plaintext_string winrt_encryption::decrypt() const
 win32_encryption::win32_encryption(const std::wstring &data) :
     m_numCharacters(data.size())
 {
+    if (m_numCharacters == 0)
+    {
+        return;
+    }
+
     const auto dataNumBytes = data.size() * sizeof(std::wstring::value_type);
     m_buffer.resize(dataNumBytes);
     memcpy_s(m_buffer.data(), m_buffer.size(), data.c_str(), dataNumBytes);

--- a/Release/tests/functional/utils/CMakeLists.txt
+++ b/Release/tests/functional/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
   strings.cpp
   macro_test.cpp
   nonce_generator_tests.cpp
+  win32_encryption_tests.cpp
   stdafx.cpp
 )
 

--- a/Release/tests/functional/utils/stdafx.h
+++ b/Release/tests/functional/utils/stdafx.h
@@ -16,6 +16,7 @@
 
 #include "cpprest/uri.h"
 #include "cpprest/asyncrt_utils.h"
+#include "cpprest/details/web_utilities.h"
 
 #include "unittestpp.h"
 #include "utils_tests.h"

--- a/Release/tests/functional/utils/win32_encryption_tests.cpp
+++ b/Release/tests/functional/utils/win32_encryption_tests.cpp
@@ -1,0 +1,44 @@
+/***
+* Copyright (C) Microsoft. All rights reserved.
+* Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+*
+* =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+*
+* win32_encryption_tests.cpp
+*
+* Tests for win32_encryption class.
+*
+* =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+****/
+
+#include "stdafx.h"
+
+using namespace utility;
+
+namespace tests { namespace functional { namespace utils_tests {
+
+#if defined(_WIN32) && !defined(CPPREST_TARGET_XP) && !defined(__cplusplus_winrt)
+SUITE(win32_encryption)
+{
+
+TEST(win32_encryption_random_string)
+{
+    utility::string_t rndStr = utility::conversions::to_string_t("random string");
+    web::details::win32_encryption enc(rndStr);
+
+    VERIFY_ARE_EQUAL(*enc.decrypt(), rndStr);
+}
+
+TEST(win32_encryption_empty_string)
+{
+    utility::string_t emptyStr = utility::conversions::to_string_t("");
+    web::details::win32_encryption enc(emptyStr);
+
+    VERIFY_ARE_EQUAL(*enc.decrypt(), emptyStr);
+}
+
+} // SUITE(win32_encryption)
+
+#endif
+
+}}}


### PR DESCRIPTION
- do a early return if the string is empty
- i've add some tests for this class

[Link to the Issue](https://github.com/Microsoft/cpprestsdk/issues/517)