### PR TITLE
FIX Build error on Ubuntu Xenial when using OpenSSH 1.1.0b 

### DIFF
--- a/Release/libs/websocketpp/websocketpp/transport/asio/security/tls.hpp
+++ b/Release/libs/websocketpp/websocketpp/transport/asio/security/tls.hpp
@@ -307,8 +307,13 @@ protected:
      */
     lib::error_code translate_ec(boost::system::error_code ec) {
         if (ec.category() == boost::asio::error::get_ssl_category()) {
+#if defined SSL_R_SHORT_READ
             if (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ) {
                 return make_error_code(transport::error::tls_short_read);
+#else
+            if (ERR_GET_REASON(ec.value()) == boost::asio::ssl::error::stream_truncated) {
+                return make_error_code(boost::asio::ssl::error::stream_truncated);
+#endif
             } else {
                 // We know it is a TLS related error, but otherwise don't know
                 // more. Pass through as TLS generic.


### PR DESCRIPTION
I've a build error when building cpprestsdk: here the following cmake output:

    -- The C compiler identification is GNU 5.4.1
    -- The CXX compiler identification is GNU 5.4.1
    -- Check for working C compiler: /usr/bin/cc
    -- Check for working C compiler: /usr/bin/cc -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Check for working CXX compiler: /usr/bin/c++
    -- Check for working CXX compiler: /usr/bin/c++ -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Looking for pthread.h
    -- Looking for pthread.h - found
    -- Looking for pthread_create
    -- Looking for pthread_create - not found
    -- Looking for pthread_create in pthreads
    -- Looking for pthread_create in pthreads - not found
    -- Looking for pthread_create in pthread
    -- Looking for pthread_create in pthread - found
    -- Found Threads: TRUE  
    -- Setting gcc options
    -- websocketpp not found, using the embedded version
    -- Boost version: 1.65.0
    -- Found the following Boost libraries:
    --   random
    --   system
    --   thread
    --   filesystem
    --   chrono
    --   atomic
    --   date_time
    --   regex
    -- Found OpenSSL: /usr/local/lib/libssl.so;/usr/local/lib/libcrypto.so (found suitable version "1.1.0b", minimum required is "1.0.0") 
    -- Performing Test _SSL_LEAK_SUPPRESS_AVAILABLE
    -- Performing Test _SSL_LEAK_SUPPRESS_AVAILABLE - Failed
    -- Found ZLIB: /usr/local/lib/libz.so (found version "1.2.11") 
    -- Added test library httpclient_test
    -- Added test library httplistener_test
    -- Added test library json_test
    -- Added test library pplx_test
    -- Added test library streams_test
    -- Added test library uri_test
    -- Added test library utils_test
    -- Added test library websocketclient_test
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /home/xxx/projects/cpprestsdk/Release/build_host

I've got the following build error when compiling:

    In file included from /home/xxx/projects/cpprestsdk/Release/libs/websocketpp/websocketpp/config/asio_client.hpp:33:0,
                     from /home/xxx/projects/cpprestsdk/Release/src/websockets/client/ws_client_wspp.cpp:45:
    /home/xxx/projects/cpprestsdk/Release/libs/websocketpp/websocketpp/transport/asio/security/tls.hpp: In member function ‘std::error_code websocketpp::transport::asio::tls_socket::connection::translate_ec(boost::system::error_code)’:
    /home/xxx/projects/cpprestsdk/Release/libs/websocketpp/websocketpp/transport/asio/security/tls.hpp:310:47: error: ‘SSL_R_SHORT_READ’ was not declared in this scope
             if (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ) {
                                               ^
    /home/xxx/projects/cpprestsdk/Release/libs/websocketpp/websocketpp/transport/asio/security/tls.hpp:322:5: error: control reaches end of non-void function [-Werror=return-type]
     }
     ^
    cc1plus: all warnings being treated as errors
    src/CMakeFiles/cpprest.dir/build.make:590: recipe for target 'src/CMakeFiles/cpprest.dir/websockets/client/ws_client_wspp.cpp.o' failed
    make[2]: *** [src/CMakeFiles/cpprest.dir/websockets/client/ws_client_wspp.cpp.o] Error 1
    make[2]: *** Waiting for unfinished jobs....
    CMakeFiles/Makefile2:85: recipe for target 'src/CMakeFiles/cpprest.dir/all' failed
    make[1]: *** [src/CMakeFiles/cpprest.dir/all] Error 2
    Makefile:138: recipe for target 'all' failed
    make: *** [all] Error 2

I've fixed it following the patch to [websocketpp](https://github.com/LocutusOfBorg/websocketpp/commit/a1103320ae8d3b4fa0ec5ee80a95a12e2bc0ca20)