### PR TITLE
Fixed proxy credentials for http_client_asio

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -809,7 +809,7 @@ private:
     {
         std::string header;
         header.append("Proxy-Authorization: Basic ");
-        header.append(generate_base64_userpass(m_http_client->client_config().credentials()));
+        header.append(generate_base64_userpass(m_http_client->client_config().proxy().credentials()));
         header.append(CRLF);
         return header;
     }


### PR DESCRIPTION
On Linux, the HTTP client uses the wrong credentials to create the proxy_authorization header.