### PR TITLE
add in link for CMAKE_DL_LIBS for linux linking #443

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -114,10 +114,14 @@ elseif(ANDROID)
     "${ANDROID_NDK}/sources/cxx-stl/gnu-libstdc++/4.8/include/backward"
     )
 elseif(UNIX) # This includes OSX
+  if(NOT BUILD_SHARED_LIBS)
+    SET(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  endif()
 elseif(WIN32)
   add_definitions(-DUNICODE -D_UNICODE -D_WIN32_WINNT=0x0600 -DWIN32 -D_SCL_SECURE_NO_WARNINGS)
 
   if(NOT BUILD_SHARED_LIBS)
+    SET(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
     # This causes cmake to not link the test libraries separately, but instead hold onto their object files.
     set(TEST_LIBRARY_TARGET_TYPE OBJECT)
     set(Casablanca_DEFINITIONS -D_NO_ASYNCRTIMP -D_NO_PPLXIMP CACHE INTERNAL "Definitions for consume casablanca library")

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -247,6 +247,10 @@ if(ANDROID)
   target_link_libraries(cpprest PRIVATE ${ANDROID_STL_FLAGS})
 endif()
 
+if (UNIX AND NOT BUILD_SHARED_LIBS)
+  target_link_libraries(cpprest PUBLIC ${CMAKE_DL_LIBS})
+endif()
+
 # Portions specific to cpprest binary versioning.
 set (CPPREST_VERSION_MAJOR 2)
 set (CPPREST_VERSION_MINOR 9)


### PR DESCRIPTION
Issue with #443 is related to the samples not including libdl. There are a few ways to do this, and this option avoided having to modify the CMakeLists.txt file for the samples.