### PR TITLE
Reorder complete_headers call to avoid race condition

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1207,10 +1207,10 @@ private:
                 m_response.headers().add(std::move(name), std::move(value));
             }
         }
-        complete_headers();
-
         m_content_length = std::numeric_limits<size_t>::max(); // Without Content-Length header, size should be same as TCP stream - set it size_t max.
         m_response.headers().match(header_names::content_length, m_content_length);
+
+        complete_headers();
 
         // note: need to check for 'chunked' here as well, azure storage sends both
         // transfer-encoding:chunked and content-length:0 (although HTTP says not to)


### PR DESCRIPTION
A race condition exists where the headers of a response can be modified while they are being read causing the read to fail.

The condition was encountered when creating a proxy using cpprest.  The proxy forwarded the request to the backend, the backend responded, the cpprest code reads the response headers and notifies the proxy that the headers are complete.  At this point, the proxy adds additional headers to the response while at the same time, cpprest attempts to read the content-length from the headers.  This causes the read to occasionally fail because the underlying map is in an inconsistent state, resulting in a max content length which causes the following read of the body to timeout.

This fix reorders the call to complete_headers to allow cpprest to read the content-length before the call and avoid the race condition.