### PR TITLE
Adding has_<type>_field utility to json value

### DIFF
--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -544,6 +544,55 @@ public:
         /// <returns>True if the field exists, false otherwise.</returns>
         bool has_field(const utility::string_t &key) const;
 
+		/// <summary>
+		/// Tests for the presence of a number field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_number_field(const utility::string_t &key) const;
+
+		/// <summary>
+		/// Tests for the presence of an integer field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_integer_field(const utility::string_t &key) const;
+
+		/// <summary>
+		/// Tests for the presence of a double field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_double_field(const utility::string_t &key) const;
+
+		/// <summary>
+		/// Tests for the presence of a boolean field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_boolean_field(const utility::string_t &key) const;
+
+		/// <summary>
+		/// Tests for the presence of a string field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_string_field(const utility::string_t &key) const;
+
+		/// <summary>
+		/// Tests for the presence of an array field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_array_field(const utility::string_t &key) const;
+
+		/// <summary>
+		/// Tests for the presence of an object field
+		/// </summary>
+		/// <param name="key">The name of the field</param>
+		/// <returns>True if the field exists, false otherwise.</returns>
+		_ASYNCRTIMP bool has_object_field(const utility::string_t &key) const;
+
         /// <summary>
         /// Accesses a field of a JSON object.
         /// </summary>

--- a/Release/src/json/json.cpp
+++ b/Release/src/json/json.cpp
@@ -382,6 +382,41 @@ bool web::json::details::_Object::has_field(const utility::string_t &key) const
     return m_object.find(key) != m_object.end();
 }
 
+bool web::json::value::has_number_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_number();
+}
+
+bool web::json::value::has_integer_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_integer();
+}
+
+bool web::json::value::has_double_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_double();
+}
+
+bool web::json::value::has_boolean_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_boolean();
+}
+
+bool web::json::value::has_string_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_string();
+}
+
+bool web::json::value::has_array_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_array();
+}
+
+bool web::json::value::has_object_field(const utility::string_t &key) const
+{
+	return has_field(key) && at(key).is_object();
+}
+
 utility::string_t json::value::to_string() const
 {
 #ifndef _WIN32

--- a/Release/tests/functional/json/to_as_and_operators_tests.cpp
+++ b/Release/tests/functional/json/to_as_and_operators_tests.cpp
@@ -312,11 +312,66 @@ TEST(negative_get_element_array)
 
 TEST(has_field_object)
 {
+
+
     json::value v1;
     
     v1[U("a")] = json::value::number(1);
+	v1[U("b")] = json::value::boolean(true);
+	v1[U("c")] = json::value::string(U("a string"));
+	v1[U("d")] = json::value::array({});
+
+	json::value sub_field;
+	sub_field[U("x")] = json::value::number(1);
+
+	v1[U("e")] = sub_field;
+
     VERIFY_IS_TRUE(v1.has_field(U("a")));
-    VERIFY_IS_FALSE(v1.has_field(U("b")));
+	VERIFY_IS_TRUE(v1.has_field(U("b")));
+	VERIFY_IS_TRUE(v1.has_field(U("c")));
+	VERIFY_IS_TRUE(v1.has_field(U("d")));
+	VERIFY_IS_TRUE(v1.has_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_field(U("f")));
+
+	VERIFY_IS_TRUE(v1.has_number_field(U("a")));
+	VERIFY_IS_TRUE(v1.has_integer_field(U("a")));
+	VERIFY_IS_FALSE(v1.has_double_field(U("a")));
+	VERIFY_IS_FALSE(v1.has_boolean_field(U("a")));
+	VERIFY_IS_FALSE(v1.has_string_field(U("a")));
+	VERIFY_IS_FALSE(v1.has_array_field(U("a")));
+	VERIFY_IS_FALSE(v1.has_object_field(U("a")));
+
+	VERIFY_IS_TRUE(v1.has_boolean_field(U("b")));
+	VERIFY_IS_FALSE(v1.has_number_field(U("b")));
+	VERIFY_IS_FALSE(v1.has_integer_field(U("b")));
+	VERIFY_IS_FALSE(v1.has_double_field(U("b")));
+	VERIFY_IS_FALSE(v1.has_string_field(U("b")));
+	VERIFY_IS_FALSE(v1.has_array_field(U("b")));
+	VERIFY_IS_FALSE(v1.has_object_field(U("b")));
+
+	VERIFY_IS_TRUE(v1.has_string_field(U("c")));
+	VERIFY_IS_FALSE(v1.has_boolean_field(U("c")));
+	VERIFY_IS_FALSE(v1.has_number_field(U("c")));
+	VERIFY_IS_FALSE(v1.has_integer_field(U("c")));
+	VERIFY_IS_FALSE(v1.has_double_field(U("c")));
+	VERIFY_IS_FALSE(v1.has_array_field(U("c")));
+	VERIFY_IS_FALSE(v1.has_object_field(U("c")));
+
+	VERIFY_IS_TRUE(v1.has_array_field(U("d")));
+	VERIFY_IS_FALSE(v1.has_string_field(U("d")));
+	VERIFY_IS_FALSE(v1.has_boolean_field(U("d")));
+	VERIFY_IS_FALSE(v1.has_number_field(U("d")));
+	VERIFY_IS_FALSE(v1.has_integer_field(U("d")));
+	VERIFY_IS_FALSE(v1.has_double_field(U("d")));
+	VERIFY_IS_FALSE(v1.has_object_field(U("d")));
+
+	VERIFY_IS_TRUE(v1.has_object_field(U("e")));
+	VERIFY_IS_FALSE(v1.has_array_field(U("e")));
+	VERIFY_IS_FALSE(v1.has_string_field(U("e")));
+	VERIFY_IS_FALSE(v1.has_boolean_field(U("e")));
+	VERIFY_IS_FALSE(v1.has_number_field(U("e")));
+	VERIFY_IS_FALSE(v1.has_integer_field(U("e")));
+	VERIFY_IS_FALSE(v1.has_double_field(U("e")));
 
     json::value v2;
     

--- a/Release/tests/functional/json/to_as_and_operators_tests.cpp
+++ b/Release/tests/functional/json/to_as_and_operators_tests.cpp
@@ -317,61 +317,59 @@ TEST(has_field_object)
     json::value v1;
     
     v1[U("a")] = json::value::number(1);
-	v1[U("b")] = json::value::boolean(true);
-	v1[U("c")] = json::value::string(U("a string"));
-	v1[U("d")] = json::value::array({});
-
-	json::value sub_field;
-	sub_field[U("x")] = json::value::number(1);
-
-	v1[U("e")] = sub_field;
+    v1[U("b")] = json::value::boolean(true);
+    v1[U("c")] = json::value::string(U("a string"));
+    v1[U("d")] = json::value::array({});    
+    json::value sub_field;
+    sub_field[U("x")] = json::value::number(1);    
+    v1[U("e")] = sub_field;
 
     VERIFY_IS_TRUE(v1.has_field(U("a")));
-	VERIFY_IS_TRUE(v1.has_field(U("b")));
-	VERIFY_IS_TRUE(v1.has_field(U("c")));
-	VERIFY_IS_TRUE(v1.has_field(U("d")));
-	VERIFY_IS_TRUE(v1.has_field(U("e")));
+    VERIFY_IS_TRUE(v1.has_field(U("b")));
+    VERIFY_IS_TRUE(v1.has_field(U("c")));
+    VERIFY_IS_TRUE(v1.has_field(U("d")));
+    VERIFY_IS_TRUE(v1.has_field(U("e")));
     VERIFY_IS_FALSE(v1.has_field(U("f")));
 
-	VERIFY_IS_TRUE(v1.has_number_field(U("a")));
-	VERIFY_IS_TRUE(v1.has_integer_field(U("a")));
-	VERIFY_IS_FALSE(v1.has_double_field(U("a")));
-	VERIFY_IS_FALSE(v1.has_boolean_field(U("a")));
-	VERIFY_IS_FALSE(v1.has_string_field(U("a")));
-	VERIFY_IS_FALSE(v1.has_array_field(U("a")));
-	VERIFY_IS_FALSE(v1.has_object_field(U("a")));
+    VERIFY_IS_TRUE(v1.has_number_field(U("a")));
+    VERIFY_IS_TRUE(v1.has_integer_field(U("a")));
+    VERIFY_IS_FALSE(v1.has_double_field(U("a")));
+    VERIFY_IS_FALSE(v1.has_boolean_field(U("a")));
+    VERIFY_IS_FALSE(v1.has_string_field(U("a")));
+    VERIFY_IS_FALSE(v1.has_array_field(U("a")));
+    VERIFY_IS_FALSE(v1.has_object_field(U("a")));
 
-	VERIFY_IS_TRUE(v1.has_boolean_field(U("b")));
-	VERIFY_IS_FALSE(v1.has_number_field(U("b")));
-	VERIFY_IS_FALSE(v1.has_integer_field(U("b")));
-	VERIFY_IS_FALSE(v1.has_double_field(U("b")));
-	VERIFY_IS_FALSE(v1.has_string_field(U("b")));
-	VERIFY_IS_FALSE(v1.has_array_field(U("b")));
-	VERIFY_IS_FALSE(v1.has_object_field(U("b")));
+    VERIFY_IS_TRUE(v1.has_boolean_field(U("b")));
+    VERIFY_IS_FALSE(v1.has_number_field(U("b")));
+    VERIFY_IS_FALSE(v1.has_integer_field(U("b")));
+    VERIFY_IS_FALSE(v1.has_double_field(U("b")));
+    VERIFY_IS_FALSE(v1.has_string_field(U("b")));
+    VERIFY_IS_FALSE(v1.has_array_field(U("b")));
+    VERIFY_IS_FALSE(v1.has_object_field(U("b")));
 
-	VERIFY_IS_TRUE(v1.has_string_field(U("c")));
-	VERIFY_IS_FALSE(v1.has_boolean_field(U("c")));
-	VERIFY_IS_FALSE(v1.has_number_field(U("c")));
-	VERIFY_IS_FALSE(v1.has_integer_field(U("c")));
-	VERIFY_IS_FALSE(v1.has_double_field(U("c")));
-	VERIFY_IS_FALSE(v1.has_array_field(U("c")));
-	VERIFY_IS_FALSE(v1.has_object_field(U("c")));
+    VERIFY_IS_TRUE(v1.has_string_field(U("c")));
+    VERIFY_IS_FALSE(v1.has_boolean_field(U("c")));
+    VERIFY_IS_FALSE(v1.has_number_field(U("c")));
+    VERIFY_IS_FALSE(v1.has_integer_field(U("c")));
+    VERIFY_IS_FALSE(v1.has_double_field(U("c")));
+    VERIFY_IS_FALSE(v1.has_array_field(U("c")));
+    VERIFY_IS_FALSE(v1.has_object_field(U("c")));
 
-	VERIFY_IS_TRUE(v1.has_array_field(U("d")));
-	VERIFY_IS_FALSE(v1.has_string_field(U("d")));
-	VERIFY_IS_FALSE(v1.has_boolean_field(U("d")));
-	VERIFY_IS_FALSE(v1.has_number_field(U("d")));
-	VERIFY_IS_FALSE(v1.has_integer_field(U("d")));
-	VERIFY_IS_FALSE(v1.has_double_field(U("d")));
-	VERIFY_IS_FALSE(v1.has_object_field(U("d")));
+    VERIFY_IS_TRUE(v1.has_array_field(U("d")));
+    VERIFY_IS_FALSE(v1.has_string_field(U("d")));
+    VERIFY_IS_FALSE(v1.has_boolean_field(U("d")));
+    VERIFY_IS_FALSE(v1.has_number_field(U("d")));
+    VERIFY_IS_FALSE(v1.has_integer_field(U("d")));
+    VERIFY_IS_FALSE(v1.has_double_field(U("d")));
+    VERIFY_IS_FALSE(v1.has_object_field(U("d")));
 
-	VERIFY_IS_TRUE(v1.has_object_field(U("e")));
-	VERIFY_IS_FALSE(v1.has_array_field(U("e")));
-	VERIFY_IS_FALSE(v1.has_string_field(U("e")));
-	VERIFY_IS_FALSE(v1.has_boolean_field(U("e")));
-	VERIFY_IS_FALSE(v1.has_number_field(U("e")));
-	VERIFY_IS_FALSE(v1.has_integer_field(U("e")));
-	VERIFY_IS_FALSE(v1.has_double_field(U("e")));
+    VERIFY_IS_TRUE(v1.has_object_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_array_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_string_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_boolean_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_number_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_integer_field(U("e")));
+    VERIFY_IS_FALSE(v1.has_double_field(U("e")));
 
     json::value v2;
     


### PR DESCRIPTION
In our code base we have a repeating pattern of accessing json objects while interpreting server responses.

It looks something like as follows:

`
if(val.has_field(U("key")) && val.at(U("key")).is_string())
{
   something =  val.at(U("key")).as_string()
}
`

Both of these checks are required or a json exception will be thrown at runtime. This is quite verbose and problematic as sometimes developers on our team forget to check both of these. I'm proposing adding a new check for each type supported in json that combines these two checks into one.

With this change the above code becomes:
`
if(val.has_string_field(U("key")))
{
   something =  val.at(U("key")).as_string()
}
`