### PR TITLE
Fix building with LibreSSL

### DIFF
--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -73,7 +73,7 @@ static struct ASIO_SSL_memory_leak_suppress
 {
     ~ASIO_SSL_memory_leak_suppress()
     {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
         ::SSL_COMP_free_compression_methods();
 #endif
     }
@@ -210,7 +210,7 @@ public:
                     return rfc2818(preverified, verifyCtx);
                 });
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
                 // OpenSSL stores some per thread state that never will be cleaned up until
                 // the dll is unloaded. If static linking, like we do, the state isn't cleaned up
                 // at all and will be reported as leaks.
@@ -382,7 +382,7 @@ public:
             crossplat::JVM.load()->DetachCurrentThread();
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
             // OpenSSL stores some per thread state that never will be cleaned up until
             // the dll is unloaded. If static linking, like we do, the state isn't cleaned up
             // at all and will be reported as leaks.


### PR DESCRIPTION
LibreSSL is backwards compatible with OpenSSL 1.0, however it reports
it's version number as 2.0, which then causes build failures when using
OPENSSL_VERSION_NUMBER.

Adding a check for LIBRESSL_VERSION_NUMBER when checking if the OpenSSL
version number is < 0x10100000L fixes the issue.