### PR TITLE
Add support for retrieving HTTP version of a request in HTTP listener

### DIFF
--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -921,6 +921,9 @@ public:
     /// <returns>The remote IP address.</returns>
     const utility::string_t& remote_address() const { return _m_impl->remote_address(); }
 
+    CASABLANCA_DEPRECATED("Use `remote_address()` instead.")
+    const utility::string_t& get_remote_address() const { return _m_impl->remote_address(); }
+
     /// <summary>
     /// Extract the body of the request message as a string value, checking that the content type is a MIME text type.
     /// A body can only be extracted once because in some cases an optimization is made where the data is 'moved' out.

--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -731,7 +731,7 @@ public:
 
     _ASYNCRTIMP void set_request_uri(const uri&);
 
-    const http_version& http_version() const { return m_http_version; }
+    const http::http_version& http_version() const { return m_http_version; }
 
     const utility::string_t& remote_address() const { return m_remote_address; }
 
@@ -901,7 +901,7 @@ public:
     /// Returns the HTTP protocol version of this request message.
     /// </summary>
     /// <returns>The HTTP protocol version.</returns>
-    const http_version& http_version() const { return _m_impl->http_version(); }
+    const http::http_version& http_version() const { return _m_impl->http_version(); }
 
     /// <summary>
     /// Returns a string representation of the remote IP address.

--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -46,7 +46,19 @@ namespace client
 /// <summary>
 /// Represents the HTTP protocol version of a message, as {major, minor}.
 /// </summary>
-typedef std::pair<uint16_t, uint16_t> http_version;
+struct http_version
+{
+    uint8_t major;
+    uint8_t minor;
+
+    inline bool operator==(const http_version& other) const { return major == other.major && minor == other.minor; }
+    inline bool operator<(const http_version& other) const { return major < other.major || (major == other.major && minor < other.minor); }
+
+    inline bool operator!=(const http_version& other) const { return !(*this == other); }
+    inline bool operator>=(const http_version& other) const { return !(*this < other); }
+    inline bool operator>(const http_version& other) const { return !(*this < other || *this == other); }
+    inline bool operator<=(const http_version& other) const { return *this < other || *this == other; }
+};
 
 /// <summary>
 /// Predefined HTTP protocol versions.
@@ -54,9 +66,9 @@ typedef std::pair<uint16_t, uint16_t> http_version;
 class http_versions
 {
 public:
-    _ASYNCRTIMP const static http_version HTTP_0_9;
-    _ASYNCRTIMP const static http_version HTTP_1_0;
-    _ASYNCRTIMP const static http_version HTTP_1_1;
+    _ASYNCRTIMP static const http_version HTTP_0_9;
+    _ASYNCRTIMP static const http_version HTTP_1_0;
+    _ASYNCRTIMP static const http_version HTTP_1_1;
 };
 
 /// <summary>
@@ -731,7 +743,7 @@ public:
 
     _ASYNCRTIMP void set_request_uri(const uri&);
 
-    const http::http_version& http_version() const { return m_http_version; }
+    http::http_version http_version() const { return m_http_version; }
 
     const utility::string_t& remote_address() const { return m_remote_address; }
 
@@ -901,7 +913,7 @@ public:
     /// Returns the HTTP protocol version of this request message.
     /// </summary>
     /// <returns>The HTTP protocol version.</returns>
-    const http::http_version& http_version() const { return _m_impl->http_version(); }
+    http::http_version http_version() const { return _m_impl->http_version(); }
 
     /// <summary>
     /// Returns a string representation of the remote IP address.

--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -901,13 +901,13 @@ public:
     /// Returns the HTTP protocol version of this request message.
     /// </summary>
     /// <returns>The HTTP protocol version.</returns>
-    const http_version& get_http_version() const { return _m_impl->http_version(); }
+    const http_version& http_version() const { return _m_impl->http_version(); }
 
     /// <summary>
     /// Returns a string representation of the remote IP address.
     /// </summary>
     /// <returns>The remote IP address.</returns>
-    const utility::string_t& get_remote_address() const { return _m_impl->remote_address(); }
+    const utility::string_t& remote_address() const { return _m_impl->remote_address(); }
 
     /// <summary>
     /// Extract the body of the request message as a string value, checking that the content type is a MIME text type.

--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -44,6 +44,22 @@ namespace client
 }
 
 /// <summary>
+/// Represents the HTTP protocol version of a message, as {major, minor}.
+/// </summary>
+typedef std::pair<uint16_t, uint16_t> http_version;
+
+/// <summary>
+/// Predefined HTTP protocol versions.
+/// </summary>
+class http_versions
+{
+public:
+    _ASYNCRTIMP const static http_version HTTP_0_9;
+    _ASYNCRTIMP const static http_version HTTP_1_0;
+    _ASYNCRTIMP const static http_version HTTP_1_1;
+};
+
+/// <summary>
 /// Predefined method strings for the standard HTTP methods mentioned in the
 /// HTTP 1.1 specification.
 /// </summary>
@@ -715,6 +731,8 @@ public:
 
     _ASYNCRTIMP void set_request_uri(const uri&);
 
+    const http_version& http_version() const { return m_http_version; }
+
     const utility::string_t& remote_address() const { return m_remote_address; }
 
     const pplx::cancellation_token &cancellation_token() const { return m_cancellationToken; }
@@ -757,6 +775,8 @@ public:
 
     void _set_base_uri(const http::uri &base_uri) { m_base_uri = base_uri; }
 
+    void _set_http_version(const http::http_version &http_version) { m_http_version = http_version; }
+
     void _set_remote_address(const utility::string_t &remote_address) { m_remote_address = remote_address; }
 
 private:
@@ -782,6 +802,8 @@ private:
     std::shared_ptr<progress_handler> m_progress_handler;
 
     pplx::task_completion_event<http_response> m_response;
+
+    http::http_version m_http_version;
 
     utility::string_t m_remote_address;
 };
@@ -874,6 +896,12 @@ public:
     /// Use the http_headers::add to fill in desired headers.
     /// </remarks>
     const http_headers &headers() const { return _m_impl->headers(); }
+
+    /// <summary>
+    /// Returns the HTTP protocol version of this request message.
+    /// </summary>
+    /// <returns>The HTTP protocol version.</returns>
+    const http_version& get_http_version() const { return _m_impl->http_version(); }
 
     /// <summary>
     /// Returns a string representation of the remote IP address.

--- a/Release/src/http/common/http_msg.cpp
+++ b/Release/src/http/common/http_msg.cpp
@@ -995,7 +995,8 @@ details::_http_request::_http_request(http::method mtd)
   : m_method(std::move(mtd)),
     m_initiated_response(0),
     m_server_context(),
-    m_cancellationToken(pplx::cancellation_token::none())
+    m_cancellationToken(pplx::cancellation_token::none()),
+    m_http_version(http::http_version{0, 0})
 {
     if(m_method.empty())
     {
@@ -1006,13 +1007,14 @@ details::_http_request::_http_request(http::method mtd)
 details::_http_request::_http_request(std::unique_ptr<http::details::_http_server_context> server_context)
   : m_initiated_response(0),
     m_server_context(std::move(server_context)),
-    m_cancellationToken(pplx::cancellation_token::none())
+    m_cancellationToken(pplx::cancellation_token::none()),
+    m_http_version(http::http_version{0, 0})
 {
 }
 
-const http_version http_versions::HTTP_0_9{ 0, 9 };
-const http_version http_versions::HTTP_1_0{ 1, 0 };
-const http_version http_versions::HTTP_1_1{ 1, 1 };
+const http_version http_versions::HTTP_0_9 = { 0, 9 };
+const http_version http_versions::HTTP_1_0 = { 1, 0 };
+const http_version http_versions::HTTP_1_1 = { 1, 1 };
 
 #define _METHODS
 #define DAT(a,b) const method methods::a = b;

--- a/Release/src/http/common/http_msg.cpp
+++ b/Release/src/http/common/http_msg.cpp
@@ -1010,6 +1010,10 @@ details::_http_request::_http_request(std::unique_ptr<http::details::_http_serve
 {
 }
 
+const http_version http_versions::HTTP_0_9{ 0, 9 };
+const http_version http_versions::HTTP_1_0{ 1, 0 };
+const http_version http_versions::HTTP_1_1{ 1, 1 };
+
 #define _METHODS
 #define DAT(a,b) const method methods::a = b;
 #include "cpprest/details/http_constants.dat"

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -649,17 +649,20 @@ will_deref_and_erase_t asio_server_connection::handle_http_line(const boost::sys
         // Get the version
         std::string http_version = http_path_and_version.substr(http_path_and_version.size() - VersionPortionSize + 1, VersionPortionSize - 2);
 
+        auto m_request_impl = m_request._get_impl().get();
+        web::http::http_version parsed_version = { 0, 0 };
         if (boost::starts_with(http_version, "HTTP/"))
         {
             std::istringstream version{ http_version.substr(5) };
-            unsigned int major = 0; version >> major;
+            version >> parsed_version.major;
             char dot; version >> dot;
-            unsigned int minor = 0; version >> minor;
-            m_request._get_impl()->_set_http_version({ (uint16_t)major, (uint16_t)minor });
+            version >> parsed_version.minor;
+
+            m_request_impl->_set_http_version(parsed_version);
         }
 
         // if HTTP version is 1.0 then disable pipelining
-        if (http_version == "HTTP/1.0")
+        if (parsed_version == web::http::http_versions::HTTP_1_0)
         {
             m_close = true;
         }

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -648,6 +648,16 @@ will_deref_and_erase_t asio_server_connection::handle_http_line(const boost::sys
 
         // Get the version
         std::string http_version = http_path_and_version.substr(http_path_and_version.size() - VersionPortionSize + 1, VersionPortionSize - 2);
+
+        if (boost::starts_with(http_version, "HTTP/"))
+        {
+            std::istringstream version{ http_version.substr(5) };
+            unsigned int major = 0; version >> major;
+            char dot; version >> dot;
+            unsigned int minor = 0; version >> minor;
+            m_request._get_impl()->_set_http_version({ (uint16_t)major, (uint16_t)minor });
+        }
+
         // if HTTP version is 1.0 then disable pipelining
         if (http_version == "HTTP/1.0")
         {

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -665,7 +665,12 @@ will_deref_and_erase_t asio_server_connection::handle_http_line(const boost::sys
         }
 
         // Get the remote IP address
-        m_request._get_impl()->_set_remote_address(utility::conversions::to_string_t(m_socket->remote_endpoint().address().to_string()));
+        boost::system::error_code socket_ec;
+        auto endpoint = m_socket->remote_endpoint(socket_ec);
+        if (!socket_ec)
+        {
+            m_request._get_impl()->_set_remote_address(utility::conversions::to_string_t(endpoint.address().to_string()));
+        }
 
         return handle_headers();
     }

--- a/Release/src/http/listener/http_server_httpsys.cpp
+++ b/Release/src/http/listener/http_server_httpsys.cpp
@@ -557,6 +557,9 @@ void windows_request_context::read_headers_io_completion(DWORD error_code, DWORD
         m_msg.set_method(parse_request_method(m_request));
         parse_http_headers(m_request->Headers, m_msg.headers());
 
+        // Get the version
+        m_msg._get_impl()->_set_http_version({ m_request->Version.MajorVersion, m_request->Version.MinorVersion });
+
         // Retrieve the remote IP address
         std::vector<wchar_t> remoteAddressBuffer(50);
 

--- a/Release/src/http/listener/http_server_httpsys.cpp
+++ b/Release/src/http/listener/http_server_httpsys.cpp
@@ -557,8 +557,7 @@ void windows_request_context::read_headers_io_completion(DWORD error_code, DWORD
         m_msg.set_method(parse_request_method(m_request));
         parse_http_headers(m_request->Headers, m_msg.headers());
 
-        // Get the version
-        m_msg._get_impl()->_set_http_version({ m_request->Version.MajorVersion, m_request->Version.MinorVersion });
+        m_msg._get_impl()->_set_http_version({ (uint8_t)m_request->Version.MajorVersion, (uint8_t)m_request->Version.MinorVersion });
 
         // Retrieve the remote IP address
         std::vector<wchar_t> remoteAddressBuffer(50);

--- a/Release/tests/functional/http/listener/request_handler_tests.cpp
+++ b/Release/tests/functional/http/listener/request_handler_tests.cpp
@@ -448,6 +448,39 @@ TEST_FIXTURE(uri_address, test_leaks)
     listener.close().wait();
 }
 
+TEST_FIXTURE(uri_address, http_version)
+{
+    http_listener listener(U("http://localhost:45678/path1"));
+    listener.open().wait();
+
+    test_http_client::scoped_client client(U("http://localhost:45678"));
+    test_http_client * p_client = client.client();
+
+    volatile unsigned long requestCount = 0;
+
+    listener.support(methods::GET, [&requestCount](http_request request)
+    {
+        const auto& httpVersion = request.http_version();
+
+        // All clients currently use HTTP/1.1
+        VERIFY_IS_TRUE(httpVersion == http_versions::HTTP_1_1);
+
+        os_utilities::interlocked_increment(&requestCount);
+        request.reply(status_codes::NoContent);
+    });
+
+    // Send a request to the listener
+    VERIFY_ARE_EQUAL(0, p_client->request(methods::GET, U("/path1")));
+
+    p_client->next_response().then([](test_response *p_response)
+    {
+        http_asserts::assert_test_response_equals(p_response, status_codes::NoContent);
+    }).wait();
+
+    VERIFY_IS_TRUE(requestCount >= 1);
+    listener.close().wait();
+}
+
 TEST_FIXTURE(uri_address, remote_address)
 {
     http_listener listener(U("http://localhost:45678/path1"));

--- a/Release/tests/functional/http/listener/request_handler_tests.cpp
+++ b/Release/tests/functional/http/listener/request_handler_tests.cpp
@@ -460,7 +460,7 @@ TEST_FIXTURE(uri_address, remote_address)
 
     listener.support(methods::GET, [&requestCount](http_request request)
     {
-        const string_t& remoteAddr = request.get_remote_address();
+        const string_t& remoteAddr = request.remote_address();
         const string_t& localhost4 = string_t(U("127.0.0.1"));
         const string_t& localhost6 = string_t(U("::1"));
 


### PR DESCRIPTION
This PR follows on from #507 by providing a mechanism to allow the HTTP version of the incoming message to be retrieved in the HTTP listener. (One motivation is to allow construction of access logs in Common Log Format.) A basic unit test is included.

It also changes http_request::get_remote_address() introduced by #507 to http_request::remote_address() for consistency with pre-existing member functions of this class.

It also includes a commit that fixes #545 which has been reported against #507.