### PR TITLE
Fix an issue where requests sent via authenticated proxies could not be redirected

### DIFF
--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -1038,6 +1038,25 @@ private:
         }
     }
 
+    static utility::string_t get_request_url(HINTERNET hRequestHandle)
+    {
+        DWORD urlSize{ 0 };
+        if(FALSE == WinHttpQueryOption(hRequestHandle, WINHTTP_OPTION_URL, nullptr, &urlSize) || urlSize == 0)
+        {
+            return U("");
+        }
+
+        auto urlwchar = new WCHAR[urlSize / sizeof(WCHAR)];
+
+        WinHttpQueryOption(hRequestHandle, WINHTTP_OPTION_URL, (void*)urlwchar, &urlSize);
+
+        utility::string_t url(urlwchar);
+
+        delete[] urlwchar;
+
+        return url;
+    }
+
     // Returns true if we handle successfully and resending the request
     // or false if we fail to handle.
     static bool handle_authentication_failure(
@@ -1094,10 +1113,22 @@ private:
                 cred = p_request_context->m_http_client->client_config().credentials();
                 p_request_context->m_server_authentication_tried = true;
             }
-            else if (dwAuthTarget == WINHTTP_AUTH_TARGET_PROXY && !p_request_context->m_proxy_authentication_tried)
+            else if (dwAuthTarget == WINHTTP_AUTH_TARGET_PROXY)
             {
-                cred = p_request_context->m_http_client->client_config().proxy().credentials();
-                p_request_context->m_proxy_authentication_tried = true;
+                bool is_redirect = false;
+                try
+                {
+                    web::uri current_uri(get_request_url(hRequestHandle));
+                    is_redirect = p_request_context->m_request.absolute_uri().to_string() != current_uri.to_string();	
+                }
+                catch (const std::exception&) {}
+     
+                // If we have been redirected, then WinHttp needs the proxy credentials again to make the next request leg (which may be on a different server)
+                if (is_redirect || !p_request_context->m_proxy_authentication_tried)
+                {
+                    cred = p_request_context->m_http_client->client_config().proxy().credentials();
+                    p_request_context->m_proxy_authentication_tried = true;
+                }
             }
 
             // No credentials found so can't resend.


### PR DESCRIPTION
There is a scenario where a client connects to a webserver via an authenticated proxy (requiring user supplied credentials) and is then redirected (eg via a HTTP 302) to another webserver. 

When the request is redirected to another webserver then WinHTTP will need to traverse the authenticated proxy again. However, the current code doesnt handle this well. 

It currently sets a bool flag to indicate that the proxy creds have already been supplied once (during the first request) and so should not be applied again (so as to avoid a 407 loop with the proxy in the case where the credentials are wrong). 

The logic needs to be more nuanced however, to allow the supplying of the credentials to WinHTTP in the case of a redirect, to allow the 2nd connection to traverse the authenticated proxy.