### PR TITLE
fix compiling with non-glib Linux c libraries

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -42,6 +42,7 @@ include(cmake/cpprest_find_boost.cmake)
 include(cmake/cpprest_find_zlib.cmake)
 include(cmake/cpprest_find_openssl.cmake)
 include(cmake/cpprest_find_websocketpp.cmake)
+include(CheckIncludeFiles)
 
 find_package(Threads REQUIRED)
 if(THREADS_HAVE_PTHREAD_ARG)
@@ -56,6 +57,7 @@ if(CPPREST_EXCLUDE_WEBSOCKETS)
   set(CPPREST_WEBSOCKETS_IMPL none CACHE STRING "Internal use.")
 endif()
 
+CHECK_INCLUDE_FILES(xlocale.h HAVE_XLOCALE_H)
 if(APPLE) # Note: also iOS
   set(CPPREST_PPLX_IMPL apple CACHE STRING "Internal use.")
   set(CPPREST_WEBSOCKETS_IMPL wspp CACHE STRING "Internal use.")

--- a/Release/include/cpprest/asyncrt_utils.h
+++ b/Release/include/cpprest/asyncrt_utils.h
@@ -19,17 +19,17 @@
 #include <system_error>
 #include <random>
 #include <locale.h>
-
 #include "pplx/pplxtasks.h"
 #include "cpprest/details/basic_types.h"
 
 #if !defined(_WIN32) || (_MSC_VER >= 1700)
+#include <sys/time.h>
 #include <chrono>
 #endif
 
 #ifndef _WIN32
 #include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) && !defined(__GLIBC__) // CodePlex 269
+#if !defined(ANDROID) && !defined(__ANDROID__) && defined(HAVE_XLOCALE_H) // CodePlex 269
 /* Systems using glibc: xlocale.h has been removed from glibc 2.26
    The above include of locale.h is sufficient
    Further details: https://sourceware.org/git/?p=glibc.git;a=commit;h=f0be25b6336db7492e47d2e8e72eb8af53b5506d */

--- a/Release/include/cpprest/asyncrt_utils.h
+++ b/Release/include/cpprest/asyncrt_utils.h
@@ -23,11 +23,11 @@
 #include "cpprest/details/basic_types.h"
 
 #if !defined(_WIN32) || (_MSC_VER >= 1700)
-#include <sys/time.h>
 #include <chrono>
 #endif
 
 #ifndef _WIN32
+#include <sys/time.h>
 #include <boost/algorithm/string.hpp>
 #if !defined(ANDROID) && !defined(__ANDROID__) && defined(HAVE_XLOCALE_H) // CodePlex 269
 /* Systems using glibc: xlocale.h has been removed from glibc 2.26


### PR DESCRIPTION
This commit fixes building against uclibc and musl c libraries.

- musl requires sys/time.h
- musl and uclibc don't define __GLIBC__, and don't include xlocal.h.

Instead of adding more define checks, have cmake check for the header and
set the define "HAVE_XLOCALE_H", then check for that instead.