### PR TITLE
Resolve gcc "warning: comparison between signed and unsigned integer expressions [-Wsign-compare]"

### DIFF
--- a/Release/include/cpprest/filestream.h
+++ b/Release/include/cpprest/filestream.h
@@ -360,7 +360,7 @@ namespace details {
 
             size_t written = _putn_fsb(m_info, callback, ptr, count, sizeof(_CharType));
 
-            if ( written != 0 && written != -1 )
+            if ( written != 0 && written != size_t(-1) )
             {
                 delete callback;
                 written = written/sizeof(_CharType);
@@ -572,7 +572,7 @@ namespace details {
 
                 size_t read = _getn_fsb(m_info, callback, ptr, count, sizeof(_CharType));
 
-                if ( read != 0 && read != -1)
+                if ( read != 0 && read != size_t(-1) )
                 {
                     delete callback;
                     pplx::extensibility::scoped_recursive_lock_t lck(m_info->m_lock);


### PR DESCRIPTION
Some functions in cpprest/details/fileio.h return (unsigned) size_t but are documented with e.g. <returns>0 if the read request is still outstanding, -1 if the request failed, otherwise the size of the data read into the buffer</returns>.