### PR TITLE
fix build by gcc error: -Werror=type-limits

### DIFF
--- a/Release/src/uri/uri.cpp
+++ b/Release/src/uri/uri.cpp
@@ -673,7 +673,7 @@ utility::string_t uri::decode(const utility::string_t &encoded)
 
             raw.push_back(static_cast<char>(decimal_value));
         }
-        else if (*iter > CHAR_MAX || *iter < 0)
+        else if (static_cast<unsigned char>(*iter) > CHAR_MAX)
         {
             throw uri_exception("Invalid encoded URI string, must be entirely ascii");
         }


### PR DESCRIPTION
Fix https://github.com/Microsoft/cpprestsdk/issues/595

We known , `CHAR_MAX`= 127, ascii `0~127`.