### PR TITLE
Define http_listener if CPPREST_FORCE_HTTP_LISTENER_ASIO is defined

### DIFF
--- a/Release/include/cpprest/http_listener.h
+++ b/Release/include/cpprest/http_listener.h
@@ -21,7 +21,7 @@
 #include <boost/asio/ssl.hpp>
 #endif
 
-#if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt))
+#if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt)) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 
 namespace web
 {


### PR DESCRIPTION
When cpprestsdk is built with ``CPPREST_HTTP_LISTENER_IMPL = asio`` on Windows, for testing purposes (I'm trying to debug an issue encountered on Linux), the following complete source code fails to compile:

```C++
#include "cpprest/http_listener.h"
using web::http::experimental::listener::http_listener;
```

This is a one-line fix. (It's possible that the various preprocessor conditional expressions in this header should all be made more consistent.)