### PR TITLE
Making crossplat::threadpool::shared_instance() safe to use in cpprest DLL

### DIFF
--- a/Release/include/pplx/threadpool.h
+++ b/Release/include/pplx/threadpool.h
@@ -52,7 +52,7 @@ using java_local_ref = std::unique_ptr<typename std::remove_pointer<T>::type, ja
 class threadpool
 {
 public:
-    static threadpool& shared_instance();
+    _ASYNCRTIMP static threadpool& shared_instance();
     _ASYNCRTIMP static std::unique_ptr<threadpool> __cdecl construct(size_t num_threads);
 
     virtual ~threadpool() = default;

--- a/Release/src/pplx/threadpool.cpp
+++ b/Release/src/pplx/threadpool.cpp
@@ -9,16 +9,7 @@
 #if !defined(CPPREST_EXCLUDE_WEBSOCKETS) || !defined(_WIN32)
 #include "pplx/threadpool.h"
 
-#if !defined(_WIN32)
-#define CPPREST_PTHREADS
-#endif
-
-#if defined(CPPREST_PTHREADS)
-#include <pthread.h>
-#else
-#include <thread>
-#endif
-
+#include <boost/asio/detail/thread.hpp>
 #include <vector>
 
 #if defined(__ANDROID__)
@@ -44,37 +35,14 @@ struct threadpool_impl final : crossplat::threadpool
         m_service.stop();
         for (auto iter = m_threads.begin(); iter != m_threads.end(); ++iter)
         {
-#if defined(CPPREST_PTHREADS)
-            pthread_t t = *iter;
-            void* res;
-            pthread_join(t, &res);
-#elif defined (_WIN32) && defined(_WINDLL)
-            if (boost::asio::detail::win_thread::terminate_threads())
-            {
-                ::TerminateThread(iter->native_handle(), 0);
-                iter->detach();
-            }
-            else
-            {
-                iter->join();
-            }
-#else
-            iter->join();
-#endif
+            (*iter)->join();
         }
     }
 
 private:
     void add_thread()
     {
-#ifdef CPPREST_PTHREADS
-        pthread_t t;
-        auto result = pthread_create(&t, nullptr, &thread_start, this);
-        if (result == 0)
-            m_threads.push_back(t);
-#else
-        m_threads.push_back(std::thread(&thread_start, this));
-#endif
+        m_threads.push_back(std::unique_ptr<boost::asio::detail::thread>(new boost::asio::detail::thread([&]{ thread_start(this); })));
     }
 
 #if defined(__ANDROID__)
@@ -99,11 +67,7 @@ private:
         return arg;
     }
 
-#if defined(CPPREST_PTHREADS)
-    std::vector<pthread_t> m_threads;
-#else
-    std::vector<std::thread> m_threads;
-#endif
+    std::vector<std::unique_ptr<boost::asio::detail::thread>> m_threads;
     boost::asio::io_service::work m_work;
 };
 }
@@ -154,7 +118,7 @@ threadpool& threadpool::shared_instance()
     {
         ~restore_terminate_threads()
         {
-            boost::asio::detail::win_thread::set_terminate_threads(terminate_threads);
+            boost::asio::detail::thread::set_terminate_threads(terminate_threads);
         }
     } destroyed_after;
 
@@ -164,8 +128,8 @@ threadpool& threadpool::shared_instance()
     {
         ~enforce_terminate_threads()
         {
-            terminate_threads = boost::asio::detail::win_thread::terminate_threads();
-            boost::asio::detail::win_thread::set_terminate_threads(true);
+            terminate_threads = boost::asio::detail::thread::terminate_threads();
+            boost::asio::detail::thread::set_terminate_threads(true);
         }
     } destroyed_before;
 

--- a/Release/src/pplx/threadpool.cpp
+++ b/Release/src/pplx/threadpool.cpp
@@ -107,9 +107,9 @@ threadpool& threadpool::shared_instance()
     return s_shared;
 }
 
-#elif defined (_WIN32) && defined(_WINDLL)
+#elif defined(_WIN32)
 
-// if built as a DLL, the threadpool shared instance will be destroyed at DLL_PROCESS_DETACH,
+// if linked into a DLL, the threadpool shared instance will be destroyed at DLL_PROCESS_DETACH,
 // at which stage joining threads causes deadlock, hence this dance
 threadpool& threadpool::shared_instance()
 {


### PR DESCRIPTION
This took me a while to track down. While investigating PR #608, on Windows / VS 2013, I found that many of the test suites would more often than not complete successfully, but then the test_runner exe wouldn't exit. I found this was due to deadlock while the ``test_module_loader`` was unloading DLLs. The culprit is the destruction of the ``static threadpool_impl`` inside ``crossplat::threadpool::shared_instance()``. Its destructor must join all the threads in the pool. This is likely to deadlock because in ``DllMain`` at ``DLL_PROCESS_DETACH``, the loader lock is held, and the thread to be joined therefore cannot signal thread termination by ``DLL_THREAD_DETACH``. (A quick web search finds many explanations of this, including some good ones on Microsoft's own The Old New Thing.)

Why hasn't this been reported before? I assume mostly on Windows, people aren't using e.g. ``CPPREST_FORCE_HTTP_LISTENER_ASIO`` or if they are, they aren't explicitly unloading the cpprest DLL until process termination.

There are two approaches to fixing this:

1. Don't expose a shared instance via the current API. A reference-counted interface, e.g. exposing ``shared_ptr<threadpool>``, could work.
2. Keep the API. Jump through hoops internally to ensure we can't deadlock in the destruction of the static instance.

Assuming 2 is preferable, I ultimately discovered that asio already provides the mechanism to solve this exact issue. And it has been present and documented in asio since at least Boost 1.37.0, so although it is in the namespace ``boost::asio::detail`` I think it can be relied on. I have tried Boost 1.65.1 (current) and Boost 1.54.0 (cpprestsdk's documented minimum version). I have run tests on both Windows and Linux platforms.

Implementation notes:

* I'd have kept the ``#if defined(CPPREST_PTHREADS)`` alternative, but ``boost::asio::detail::thread`` picks Windows threads or POSIX threads (or falls back to ``std::thread``) appropriately anyway, so the code is now mostly simpler than it was too.
* I'd have used ``std::vector<boost::asio::detail::thread>``, but for some reason the ``thread`` type isn't movable, hence the use of ``std::unique_ptr``.
