### PR TITLE
Define http_listener if CPPREST_FORCE_HTTP_LISTENER_ASIO is defined (part 2)

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -44,6 +44,33 @@
 #include <unordered_set>
 #include <memory>
 
+#if defined(__GNUC__)
+
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+#define AND_CAPTURE_MEMBER_FUNCTION_POINTERS
+#else
+// GCC Bug 56222 - Pointer to member in lambda should not require this to be captured
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56222
+// GCC Bug 51494 - Legal program rejection - capturing "this" when using static method inside lambda
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51494
+#define AND_CAPTURE_MEMBER_FUNCTION_POINTERS , this
+#endif
+
+#elif defined(_MSC_VER)
+
+#if _MSC_VER >= 1900
+#define AND_CAPTURE_MEMBER_FUNCTION_POINTERS
+#else
+// This bug also afflicts VS2013 which incorrectly reports "warning C4573: the usage of 'symbol' requires the compiler to capture 'this' but the current default capture mode does not allow it"
+#define AND_CAPTURE_MEMBER_FUNCTION_POINTERS , this
+#endif
+
+#else
+
+#define AND_CAPTURE_MEMBER_FUNCTION_POINTERS
+
+#endif
+
 using boost::asio::ip::tcp;
 
 #ifdef __ANDROID__
@@ -620,7 +647,7 @@ public:
             proxy_host = utility::conversions::to_utf8string(proxy_uri.host());
         }
         
-        auto start_http_request_flow = [proxy_type, proxy_host, proxy_port](std::shared_ptr<asio_context> ctx)
+        auto start_http_request_flow = [proxy_type, proxy_host, proxy_port AND_CAPTURE_MEMBER_FUNCTION_POINTERS](std::shared_ptr<asio_context> ctx)
         {
             if (ctx->m_request._cancellation_token().is_canceled())
             {
@@ -1010,7 +1037,7 @@ private:
         auto readbuf = _get_readbuffer();
         uint8_t *buf = boost::asio::buffer_cast<uint8_t *>(m_body_buf.prepare(chunkSize + http::details::chunked_encoding::additional_encoding_space));
         const auto this_request = shared_from_this();
-        readbuf.getn(buf + http::details::chunked_encoding::data_offset, chunkSize).then([this_request, buf, chunkSize](pplx::task<size_t> op)
+        readbuf.getn(buf + http::details::chunked_encoding::data_offset, chunkSize).then([this_request, buf, chunkSize AND_CAPTURE_MEMBER_FUNCTION_POINTERS](pplx::task<size_t> op)
         {
             size_t readSize = 0;
             try
@@ -1067,7 +1094,7 @@ private:
         const auto this_request = shared_from_this();
         const auto readSize = static_cast<size_t>(std::min(static_cast<uint64_t>(m_http_client->client_config().chunksize()), m_content_length - m_uploaded));
         auto readbuf = _get_readbuffer();
-        readbuf.getn(boost::asio::buffer_cast<uint8_t *>(m_body_buf.prepare(readSize)), readSize).then([this_request](pplx::task<size_t> op)
+        readbuf.getn(boost::asio::buffer_cast<uint8_t *>(m_body_buf.prepare(readSize)), readSize).then([this_request AND_CAPTURE_MEMBER_FUNCTION_POINTERS](pplx::task<size_t> op)
         {
             try
             {
@@ -1370,7 +1397,7 @@ private:
                         auto shared_decompressed = std::make_shared<data_buffer>(std::move(decompressed));
 
                         writeBuffer.putn_nocopy(shared_decompressed->data(), shared_decompressed->size())
-                            .then([this_request, to_read, shared_decompressed](pplx::task<size_t> op)
+                            .then([this_request, to_read, shared_decompressed AND_CAPTURE_MEMBER_FUNCTION_POINTERS](pplx::task<size_t> op)
                         {
                             try
                             {
@@ -1388,7 +1415,7 @@ private:
                 }
                 else
                 {
-                    writeBuffer.putn_nocopy(boost::asio::buffer_cast<const uint8_t *>(m_body_buf.data()), to_read).then([this_request, to_read](pplx::task<size_t> op)
+                    writeBuffer.putn_nocopy(boost::asio::buffer_cast<const uint8_t *>(m_body_buf.data()), to_read).then([this_request, to_read AND_CAPTURE_MEMBER_FUNCTION_POINTERS](pplx::task<size_t> op)
                     {
                         try
                         {
@@ -1485,7 +1512,7 @@ private:
                     auto shared_decompressed = std::make_shared<data_buffer>(std::move(decompressed));
 
                     writeBuffer.putn_nocopy(shared_decompressed->data(), shared_decompressed->size())
-                        .then([this_request, read_size, shared_decompressed](pplx::task<size_t> op)
+                        .then([this_request, read_size, shared_decompressed AND_CAPTURE_MEMBER_FUNCTION_POINTERS](pplx::task<size_t> op)
                     {
                         size_t writtenSize = 0;
                         try
@@ -1507,7 +1534,7 @@ private:
             else
             {
                 writeBuffer.putn_nocopy(boost::asio::buffer_cast<const uint8_t *>(m_body_buf.data()), read_size)
-                .then([this_request](pplx::task<size_t> op)
+                .then([this_request AND_CAPTURE_MEMBER_FUNCTION_POINTERS](pplx::task<size_t> op)
                 {
                     size_t writtenSize = 0;
                     try
@@ -1558,7 +1585,7 @@ private:
 
             m_timer.expires_from_now(m_duration);
             auto ctx = m_ctx;
-            m_timer.async_wait([ctx](const boost::system::error_code& ec)
+            m_timer.async_wait([ctx AND_CAPTURE_MEMBER_FUNCTION_POINTERS](const boost::system::error_code& ec)
                                {
                                    handle_timeout(ec, ctx);
                                });
@@ -1573,7 +1600,7 @@ private:
                 // The existing handler was canceled so schedule a new one.
                 assert(m_state == started);
                 auto ctx = m_ctx;
-                m_timer.async_wait([ctx](const boost::system::error_code& ec)
+                m_timer.async_wait([ctx AND_CAPTURE_MEMBER_FUNCTION_POINTERS](const boost::system::error_code& ec)
                 {
                     handle_timeout(ec, ctx);
                 });

--- a/Release/src/http/listener/http_listener.cpp
+++ b/Release/src/http/listener/http_listener.cpp
@@ -13,7 +13,7 @@
 
 #include "stdafx.h"
 
-#if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt))
+#if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt)) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 
 using namespace web::http::experimental;
 

--- a/Release/src/http/listener/http_server_api.cpp
+++ b/Release/src/http/listener/http_server_api.cpp
@@ -11,7 +11,7 @@
 
 #include "stdafx.h"
 
-#if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt))
+#if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt)) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 #include "http_server_impl.h"
 
 using namespace web;

--- a/Release/tests/functional/http/listener/listener_construction_tests.cpp
+++ b/Release/tests/functional/http/listener/listener_construction_tests.cpp
@@ -430,7 +430,7 @@ TEST_FIXTURE(uri_address, listener_config_creation)
     }
 }
 
-#if !defined(_WIN32) && !defined(__cplusplus_winrt)
+#if !defined(_WIN32) && !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 
 TEST_FIXTURE(uri_address, create_https_listener_get, "Ignore", "github 209")
 {
@@ -545,7 +545,6 @@ XzJTD4slrGSJrcpLt/g/Jqqdjg==
 
             for (auto&& h : all_headers)
             {
-                std::cout << "HEADER - " << h.first << ": " << h.second << std::endl;
                 VERIFY_IS_TRUE(request.headers().has(h.first));
                 VERIFY_ARE_EQUAL(h.second, request.headers().find(h.first)->second);
             }

--- a/Release/tests/functional/websockets/utilities/test_websocket_server.cpp
+++ b/Release/tests/functional/websockets/utilities/test_websocket_server.cpp
@@ -18,8 +18,9 @@
 #include "test_websocket_server.h"
 
 #ifdef _WIN32
+#pragma warning(disable : 4503) // generated too late for disable to be effective inside push/pop
 #pragma warning( push )
-#pragma warning(disable : 4100 4127 4996 4512 4701 4267 4067 4503 4005)
+#pragma warning(disable : 4100 4127 4996 4512 4701 4267 4067 4005)
 #define _WEBSOCKETPP_CPP11_STL_
 #define _WEBSOCKETPP_CONSTEXPR_TOKEN_
 #if _MSC_VER < 1900


### PR DESCRIPTION
Follow-up to PR #608, which it turns out was too simple; sorry, @ras0219-msft.

Getting ``http_listener`` itself defined wasn't enough. This PR, along with PR #611, completes things. The main commit is 823f3b737127bf23bb97fd42ab3aad3ec7cc994f, which makes sure ``http_listener_impl`` and ``http_server_api`` are defined. The other three small commits resolve some compiler warnings (and errors on VS 2013, already discussed in PR #609) and enable an additional test case appropriate when asio is in use. I haven't merged PR #611 into this, since it stands alone, but in my environment that's necessary also.