### PR TITLE
Expose http_listener configuration for the backlog

### DIFF
--- a/Release/include/cpprest/http_listener.h
+++ b/Release/include/cpprest/http_listener.h
@@ -46,6 +46,7 @@ public:
     /// </summary>
     http_listener_config()
         : m_timeout(utility::seconds(120))
+        , m_backlog(0)
     {}
 
     /// <summary>
@@ -54,6 +55,7 @@ public:
     /// <param name="other">http_listener_config to copy.</param>
     http_listener_config(const http_listener_config &other)
         : m_timeout(other.m_timeout)
+        , m_backlog(other.m_backlog)
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
         , m_ssl_context_callback(other.m_ssl_context_callback)
 #endif
@@ -65,6 +67,7 @@ public:
     /// <param name="other">http_listener_config to move from.</param>
     http_listener_config(http_listener_config &&other)
         : m_timeout(std::move(other.m_timeout))
+        , m_backlog(std::move(other.m_backlog))
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
         , m_ssl_context_callback(std::move(other.m_ssl_context_callback))
 #endif
@@ -79,6 +82,7 @@ public:
         if(this != &rhs)
         {
             m_timeout = rhs.m_timeout;
+            m_backlog = rhs.m_backlog;
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
             m_ssl_context_callback = rhs.m_ssl_context_callback;
 #endif
@@ -95,6 +99,7 @@ public:
         if(this != &rhs)
         {
             m_timeout = std::move(rhs.m_timeout);
+            m_backlog = std::move(rhs.m_backlog);
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
             m_ssl_context_callback = std::move(rhs.m_ssl_context_callback);
 #endif
@@ -120,6 +125,26 @@ public:
         m_timeout = std::move(timeout);
     }
 
+    /// <summary>
+    /// Get the listen backlog
+    /// </summary>
+    /// <returns>The maximum length of the queue of pending connections, or zero for the implementation default.</returns>
+    /// <remarks>The implementation may not honour this value.</remarks>
+    int backlog() const
+    {
+        return m_backlog;
+    }
+
+    /// <summary>
+    /// Set the listen backlog
+    /// </summary>
+    /// <param name="backlog">The maximum length of the queue of pending connections, or zero for the implementation default.</param>
+    /// <remarks>The implementation may not honour this value.</remarks>
+    void set_backlog(int backlog)
+    {
+        m_backlog = backlog;
+    }
+
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
     /// <summary>
     /// Get the callback of ssl context
@@ -143,6 +168,7 @@ public:
 private:
 
     utility::seconds m_timeout;
+    int m_backlog;
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
     std::function<void(boost::asio::ssl::context&)> m_ssl_context_callback;
 #endif


### PR DESCRIPTION
When a large number of concurrent connection requests need to be dealt with, configuring the backlog (the maximum length of the queue of pending connections on the port) can prevent the TCP stack refusing connections.

Tested on both Windows 8+ (see https://blogs.msdn.microsoft.com/winsdk/2015/06/01/winsocks-listen-backlog-offers-more-flexibility-in-windows-8/) and Linux with the ASIO-based http_listener.

I haven't been able to determine whether/how the HTTP Server API Version 2.0 on Windows allows this to be configured.
