### PR TITLE
Fix for missing 'int_type' definition in "streams.h" file

### DIFF
--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -1714,6 +1714,7 @@ private:
 template<class CharType>
 class type_parser<CharType, std::enable_if_t<sizeof(CharType) == 1, std::basic_string<wchar_t>>> : public _type_parser_base<CharType>
 {
+    typedef typename concurrency::streams::streambuf<CharType>::int_type int_type;
 public:
     static pplx::task<std::wstring> parse(streams::streambuf<CharType> buffer)
     {


### PR DESCRIPTION
Fixes #628 
Last definition of class template type_parser (compiled conditionally for _WIN32) lacks 'int_type' definition used in the _accept_char static method.

Simple copy of: `typedef typename concurrency::streams::streambuf::int_type int_type;`
from the class template above solves this issue.