### PR TITLE
Patch for Windows DLL naming

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -4,10 +4,14 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW) # use MACOSX_RPATH
 endif()
 if(UNIX)
-  project(cpprest C CXX)
+  project(cpprestsdk C CXX)
 else()
-  project(cpprest CXX)
+  project(cpprestsdk CXX)
 endif()
+
+set(CPPREST_VERSION_MAJOR 2)
+set(CPPREST_VERSION_MINOR 10)
+set(CPPREST_VERSION_REVISION 1)
 
 enable_testing()
 
@@ -34,6 +38,18 @@ endif()
 
 if(WIN32)
   set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Default filename postfix for libraries under configuration DEBUG")
+else()
+  set(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Default filename postfix for libraries under configuration DEBUG")
+endif()
+
+if(WIN32)
+  set(TOOLSET)
+  if(CMAKE_VS_PLATFORM_TOOLSET)
+    string(REGEX REPLACE "^v" "" TOOLSET "${CMAKE_VS_PLATFORM_TOOLSET}")
+  endif()
+  set(CPPREST_ABI_TAG "${TOOLSET}_${CPPREST_VERSION_MAJOR}_${CPPREST_VERSION_MINOR}" CACHE STRING "Postfix tag for the cpprest abi")
+else()
+  set(CPPREST_ABI_TAG "" CACHE STRING "Postfix tag for the cpprest abi")
 endif()
 
 if(ANDROID)

--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -32,6 +32,10 @@ else()
   set(BUILD_SAMPLES ON CACHE BOOL "Build sample applications.")
 endif()
 
+if(WIN32)
+  set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Default filename postfix for libraries under configuration DEBUG")
+endif()
+
 if(ANDROID)
   set(Boost_USE_STATIC_LIBS ON CACHE BOOL "Link against boost statically.")
 else()

--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -1714,6 +1714,7 @@ private:
 template<class CharType>
 class type_parser<CharType, std::enable_if_t<sizeof(CharType) == 1, std::basic_string<wchar_t>>> : public _type_parser_base<CharType>
 {
+    typedef typename concurrency::streams::streambuf<CharType>::int_type int_type;
 public:
     static pplx::task<std::wstring> parse(streams::streambuf<CharType> buffer)
     {

--- a/Release/include/pplx/threadpool.h
+++ b/Release/include/pplx/threadpool.h
@@ -67,9 +67,10 @@ public:
     boost::asio::io_service& service() { return m_service; }
 
 protected:
-    threadpool(size_t num_threads) : m_service(num_threads) {}
+    threadpool(size_t num_threads) : m_service(static_cast<int>(num_threads)) {}
 
     boost::asio::io_service m_service;
 };
 
 }
+

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_policy(SET CMP0022 NEW)
 
-set(CPPREST_VERSION_MAJOR 2)
-set(CPPREST_VERSION_MINOR 10)
-set(CPPREST_VERSION_REVISION 1)
-
 file(GLOB HEADERS_CPPREST "../include/cpprest/*.h" "../include/cpprest/*.hpp" "../include/cpprest/*.dat")
 file(GLOB HEADERS_PPLX "../include/pplx/*.h" "../include/pplx/*.hpp")
 file(GLOB HEADERS_DETAILS "../include/cpprest/details/*.h" "../include/cpprest/details/*.hpp" "../include/cpprest/details/*.dat" "../include/pplx/*.hpp" "../include/pplx/*.dat")
@@ -214,19 +210,8 @@ elseif(WINDOWS_STORE)
   endif()
 endif()
 
+set_target_properties(cpprest PROPERTIES OUTPUT_NAME "cpprest${CPPREST_ABI_TAG}")
 if(WIN32)
-  string(SUBSTRING ${CMAKE_VS_PLATFORM_TOOLSET} 1 -1 TOOLSET)
-  set(CPPREST_VERSION_POSTFIX "_${CPPREST_VERSION_MAJOR}_${CPPREST_VERSION_MINOR}")
-  foreach(CFG ${CMAKE_CONFIGURATION_TYPES})
-    string(TOUPPER ${CFG} CFG)
-    get_target_property(CFG_POSTFIX cpprest ${CFG}_POSTFIX)
-    if (NOT CFG_POSTFIX)
-      # forget "NOTFOUND"
-      set(CFG_POSTFIX)
-    endif()
-    set_target_properties(cpprest PROPERTIES
-      ${CFG}_POSTFIX "${TOOLSET}${CFG_POSTFIX}${CPPREST_VERSION_POSTFIX}")
-  endforeach()
 elseif(ANDROID)
   # Do not use SOVERSION on android. It is completely unsupported (and causes problems).
   # Perhaps revisit in the future? (NDK r9d, 8/7/14)

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -215,8 +215,18 @@ elseif(WINDOWS_STORE)
 endif()
 
 if(WIN32)
-  set_target_properties(cpprest PROPERTIES
-    OUTPUT_NAME "cpprest_${CPPREST_VERSION_MAJOR}_${CPPREST_VERSION_MINOR}")
+  string(SUBSTRING ${CMAKE_VS_PLATFORM_TOOLSET} 1 -1 TOOLSET)
+  set(CPPREST_VERSION_POSTFIX "_${CPPREST_VERSION_MAJOR}_${CPPREST_VERSION_MINOR}")
+  foreach(CFG ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${CFG} CFG)
+    get_target_property(CFG_POSTFIX cpprest ${CFG}_POSTFIX)
+    if (NOT CFG_POSTFIX)
+      # forget "NOTFOUND"
+      set(CFG_POSTFIX)
+    endif()
+    set_target_properties(cpprest PROPERTIES
+      ${CFG}_POSTFIX "${TOOLSET}${CFG_POSTFIX}${CPPREST_VERSION_POSTFIX}")
+  endforeach()
 elseif(ANDROID)
   # Do not use SOVERSION on android. It is completely unsupported (and causes problems).
   # Perhaps revisit in the future? (NDK r9d, 8/7/14)

--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -412,6 +412,7 @@ protected:
         DWORD access_type;
         LPCWSTR proxy_name;
         LPCWSTR proxy_bypass = WINHTTP_NO_PROXY_BYPASS;
+        utility::string_t proxy_str;
         http::uri uri;
 
         const auto& config = client_config();
@@ -485,7 +486,6 @@ protected:
             }
             else
             {
-                utility::string_t proxy_str;
                 if (uri.port() > 0)
                 {
                     utility::ostringstream_t ss;

--- a/Release/src/http/client/http_client_winrt.cpp
+++ b/Release/src/http/client/http_client_winrt.cpp
@@ -28,6 +28,9 @@ using namespace std;
 using namespace Platform;
 using namespace Microsoft::WRL;
 
+#undef min
+#undef max
+
 namespace web
 {
 namespace http

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -637,7 +637,7 @@ will_deref_and_erase_t asio_server_connection::handle_http_line(const boost::sys
         {
             m_request.set_request_uri(utility::conversions::to_string_t(http_path_and_version.substr(1, http_path_and_version.size() - VersionPortionSize - 1)));
         }
-        catch(const web::uri_exception &e)
+        catch (const std::exception& e) // may be std::range_error indicating invalid Unicode, or web::uri_exception
         {
             m_request.reply(status_codes::BadRequest, e.what());
             m_close = true;
@@ -913,7 +913,7 @@ will_deref_and_erase_t asio_server_connection::dispatch_request_to_listener()
     {
         pListener = m_p_parent->find_listener(m_request.relative_uri());
     }
-    catch (const web::uri_exception&)
+    catch (const std::exception&) // may be web::uri_exception, or std::range_error indicating invalid Unicode
     {
         m_request.reply(status_codes::BadRequest);
         (will_erase_from_parent_t)do_response();


### PR DESCRIPTION
Patch to get e.g. "cpprest140d_2_10.dll" as described in #577.