### PR TITLE
Fix string use after destruct introduced in merge commit b7fa0b1

### DIFF
--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -412,6 +412,7 @@ protected:
         DWORD access_type;
         LPCWSTR proxy_name;
         LPCWSTR proxy_bypass = WINHTTP_NO_PROXY_BYPASS;
+        utility::string_t proxy_str;
         http::uri uri;
 
         const auto& config = client_config();
@@ -485,7 +486,6 @@ protected:
             }
             else
             {
-                utility::string_t proxy_str;
                 if (uri.port() > 0)
                 {
                     utility::ostringstream_t ss;


### PR DESCRIPTION
See the comment on L480. If the uri port is not default, and is greater than 0, then a LPCWSTR (proxy_name) is pointed to a string that is then destructed before it is used. Reverted the string declaration move, so that it's lifetime is preserved after proxy_name is used.