### PR TITLE
fixed strand type to be able to build it with Boost 1.66

### DIFF
--- a/Release/libs/websocketpp/websocketpp/transport/asio/connection.hpp
+++ b/Release/libs/websocketpp/websocketpp/transport/asio/connection.hpp
@@ -422,7 +422,7 @@ protected:
         m_io_service = io_service;
 
         if (config::enable_multithreading) {
-            m_strand = lib::make_shared<boost::asio::strand>(
+            m_strand = lib::make_shared<boost::asio::io_service::strand>(
                 lib::ref(*io_service));
 
             m_async_read_handler = m_strand->wrap(lib::bind(


### PR DESCRIPTION
I've changed strand type to one that is not deprecated to be able to build the library with Boost 1.66