### PR TITLE
Overhaul the OpenSSL build scripts for Android

### DIFF
--- a/Build_android/configure.sh
+++ b/Build_android/configure.sh
@@ -47,13 +47,13 @@ do
 	"--skip-cpprestsdk")
 	    DO_CPPRESTSDK=0
 	    ;;
-	"-?"|"-h"|"--help")
-	    usage
-	    exit
-	    ;;
 	"--ndk")
 	    shift
 	    export ANDROID_NDK=$1
+	    ;;
+	"-?"|"-h"|"--help")
+	    usage
+	    exit
 	    ;;
 	*)
 	    usage
@@ -105,11 +105,13 @@ fi
 if [ "${DO_OPENSSL}" == "1" ]
 then
 (
-    if [ ! -d "openssl" ]; then mkdir openssl; fi
+    if [ ! -d "openssl" ]; then
+        mkdir openssl;
+    fi
     cd openssl
-    cp "${DIR}/openssl/Makefile" .
-    export ANDROID_NDK_ROOT="${NDK_DIR}"
-    make all
+    cp -af "${DIR}/openssl/." .
+    make all ANDROID_NDK="${NDK_DIR}" ANDROID_ABI=armeabi-v7a
+    make all ANDROID_NDK="${NDK_DIR}" ANDROID_ABI=x86
 )
 fi
 

--- a/Build_android/openssl/Makefile
+++ b/Build_android/openssl/Makefile
@@ -1,60 +1,166 @@
-SHELL := /bin/bash
-OPENSSL_VER = openssl-1.0.2k
+# Configuration parameters
+ANDROID_NDK = /opt/android-ndk-r10e
+ANDROID_HOST = linux-x86_64
+ANDROID_PLATFORM = android-18
+ANDROID_ABI = armeabi-v7a
+ANDROID_TOOLCHAIN = gcc
+ANDROID_GCC_VERSION = 4.8
+OPENSSL_VERSION = 1.0.2k
+OPENSSL_PACKAGE = openssl-$(OPENSSL_VERSION)
+OPENSSL_PATCH = $(OPENSSL_PACKAGE).patch
+OPENSSL_TARBALL = $(OPENSSL_PACKAGE).tar.gz
+OPENSSL_URL = https://www.openssl.org/source/$(OPENSSL_TARBALL)
+OPENSSL_OPTIONS = -no-ssl2 -no-ssl3 -no-comp -no-hw -no-engine
+OPENSSL_PREFIX = $(ANDROID_ABI)
+OPENSSL_SOURCE = $(OPENSSL_PACKAGE)-$(ANDROID_ABI)
+OPENSSL_CFLAGS =
 
-all: armeabi-v7a/lib/libssl.a x86/lib/libssl.a
+# Setup target parameters from ABI
+ifneq ($(findstring armeabi,$(ANDROID_ABI)),)
+ANDROID_ARCH := arm
+ANDROID_TARGET := arm-linux-androideabi
+ANDROID_TOOLCHAIN_SUFFIX := arm-linux-androideabi-
+OPENSSL_MACHINE := armv7
+OPENSSL_SYSTEM := android
+OPENSSL_TARGET := android-armeabi
+endif
+
+ifneq ($(findstring aarch64,$(ANDROID_ABI)),)
+ANDROID_ARCH := arm64
+ANDROID_TARGET := aarch64-linux-android
+ANDROID_TOOLCHAIN_SUFFIX := aarch64-linux-android-
+OPENSSL_MACHINE := aarch64
+OPENSSL_SYSTEM := android64
+OPENSSL_TARGET := android64-aarch64
+endif
+
+ifneq ($(findstring x86,$(ANDROID_ABI)),)
+ANDROID_ARCH := x86
+ANDROID_TARGET := x86
+ANDROID_TOOLCHAIN_SUFFIX := i686-linux-android-
+OPENSSL_MACHINE := i686
+OPENSSL_SYSTEM := android
+OPENSSL_TARGET := android-x86
+endif
+
+# Validate Android NDK directory paths and use fallback directories where applicable
+define direxists =
+$(if $(wildcard $(1)),$(strip $(1)),"")
+endef
+
+define findfirstdir =
+$(call direxists,$(firstword $(filter-out "",$(foreach val,$(3),$(call direxists,$(subst $(2),$(strip $(val)),$(1)))))))
+endef
+
+ifeq ($(call direxists,$(ANDROID_NDK)),"")
+$(error invalid Android NDK root directory)
+endif
+
+ANDROID_SYSROOT := $(ANDROID_NDK)/platforms/$(ANDROID_PLATFORM)/arch-$(ANDROID_ARCH)
+ifeq ($(call direxists,$(ANDROID_SYSROOT)),"")
+$(error invalid Android ABI or platform, could not locate Android NDK sysroot directory)
+endif
+
+ANDROID_GCC_VERSIONS := $(ANDROID_GCC_VERSION) 4.9 4.8
+ANDROID_GCC_PREBUILT_template := $(ANDROID_NDK)/toolchains/$(ANDROID_TARGET)-<<VERSION>>/prebuilt
+ANDROID_GCC_PREBUILT := $(call findfirstdir,$(ANDROID_GCC_PREBUILT_template),<<VERSION>>,$(ANDROID_GCC_VERSIONS))
+ifeq ($(ANDROID_GCC_PREBUILT),"")
+$(error could not determine Android NDK GCC toolchain prebuilt directory)
+endif
+
+ANDROID_HOSTS := $(ANDROID_HOST) linux-x86_64 linux-x86 darwin-x86_64 darwin-x86
+ANDROID_GCC_TOOLCHAIN_template := $(ANDROID_GCC_PREBUILT)/<<HOST>>
+ANDROID_GCC_TOOLCHAIN := $(call findfirstdir,$(ANDROID_GCC_TOOLCHAIN_template),<<HOST>>,$(ANDROID_HOSTS))
+ifeq ($(ANDROID_GCC_TOOLCHAIN),"")
+$(error could not determine Android NDK GCC toolchain host directory)
+endif
+
+ANDROID_LLVM_VERSIONS := llvm llvm-3.6 llvm-3.5 llvm-3.4
+ANDROID_LLVM_TOOLCHAIN_template := $(ANDROID_NDK)/toolchains/<<LLVM>>/prebuilt/$(notdir $(ANDROID_GCC_TOOLCHAIN))
+ANDROID_LLVM_TOOLCHAIN := $(call findfirstdir,$(ANDROID_LLVM_TOOLCHAIN_template),<<LLVM>>,$(ANDROID_LLVM_VERSIONS))
+ifeq ($(ANDROID_LLVM_TOOLCHAIN),"")
+$(error could not determine Android NDK LLVM toolchain directory)
+endif
+
+# Configure toolchain
+OPENSSL_CROSS_COMPILE :=
+OPENSSL_CC :=
+OPENSSL_RANLIB := $(ANDROID_GCC_TOOLCHAIN)/bin/$(ANDROID_TOOLCHAIN_SUFFIX)ranlib
+
+ifneq ($(findstring clang,$(ANDROID_TOOLCHAIN)),)
+OPENSSL_TARGET := $(OPENSSL_TARGET)-clang
+OPENSSL_CC := $(ANDROID_LLVM_TOOLCHAIN)/bin/clang
+endif
+
+ifneq ($(findstring gcc,$(ANDROID_TOOLCHAIN)),)
+OPENSSL_CROSS_COMPILE := $(ANDROID_TOOLCHAIN_SUFFIX)
+OPENSSL_CC := $(ANDROID_GCC_TOOLCHAIN)/bin/$(ANDROID_TOOLCHAIN_SUFFIX)gcc
+endif
+
+all: info $(OPENSSL_PREFIX)/lib/libssl.a
+
+$(OPENSSL_TARBALL):
+	@echo "Downloading OpenSSL tarball"
+	wget $(OPENSSL_URL)
+
+$(OPENSSL_PREFIX)/lib/libssl.a: $(OPENSSL_TARBALL)
+	@echo "Decompressing OpenSSL package" && \
+	( \
+		set -e; \
+		rm -rf $(OPENSSL_SOURCE); \
+		rm -rf $(OPENSSL_PACKAGE); \
+		tar xzf $(OPENSSL_TARBALL); \
+	) && \
+	mv $(OPENSSL_PACKAGE) $(OPENSSL_SOURCE)
+	@if test -f $(OPENSSL_PATCH); then \
+		echo "Patching OpenSSL source tree"; \
+		( cd $(OPENSSL_SOURCE) && patch -p1 < ../$(OPENSSL_PATCH) ); \
+	fi
+	@echo "Building OpenSSL" && \
+	export ANDROID_NDK="$(ANDROID_NDK)" && \
+	export ANDROID_API="$(ANDROID_PLATFORM)" && \
+	export ANDROID_DEV="$(ANDROID_SYSROOT)/usr" && \
+	export ANDROID_SYSROOT="$(ANDROID_SYSROOT)" && \
+	export ANDROID_GCC_TOOLCHAIN="$(ANDROID_GCC_TOOLCHAIN)" && \
+	export CROSS_SYSROOT="$(ANDROID_SYSROOT)" && \
+	export SYSROOT="$(ANDROID_SYSROOT)" && \
+	export ARCH="$(ANDROID_ARCH)" && \
+	export MACHINE="$(OPENSSL_MACHINE)" && \
+	export SYSTEM="$(OPENSSL_SYSTEM)" && \
+	export CROSS_COMPILE="$(OPENSSL_CROSS_COMPILE)" && \
+	export HOSTCC="$(ANDROID_TOOLCHAIN)" && \
+	export PATH="$(ANDROID_GCC_TOOLCHAIN)/bin:$(ANDROID_LLVM_TOOLCHAIN)/bin:$(PATH)" && \
+	( \
+		cd $(OPENSSL_SOURCE); \
+		perl Configure $(OPENSSL_TARGET) shared $(OPENSSL_OPTIONS) --prefix="`pwd`/../$(OPENSSL_PREFIX)" $(OPENSSL_CFLAGS) && \
+		make depend && \
+		make all && \
+		make install CC=$(OPENSSL_CC) RANLIB=$(OPENSSL_RANLIB); \
+	)
 
 clean:
-	rm -rf $(OPENSSL_VER)
-	rm -rf $(OPENSSL_VER)-armeabi-v7a
-	rm -rf armeabi-v7a
-	rm -rf setenv-android-x86.sh
+	@echo "Cleaning"
+	rm -rf $(OPENSSL_SOURCE)
+	rm -rf $(OPENSSL_PACKAGE)
+	rm -rf $(OPENSSL_PREFIX)
 
-setenv-android.sh:
-	wget https://wiki.openssl.org/images/7/70/Setenv-android.sh
-	mv Setenv-android.sh setenv-android.sh
-	chmod a+x setenv-android.sh
+info:
+	@echo "OpenSSL build options"
+	@echo "ANDROID_NDK = $(ANDROID_NDK)"
+	@echo "ANDROID_SYSROOT = $(ANDROID_SYSROOT)"
+	@echo "ANDROID_ABI = $(ANDROID_ABI)"
+	@echo "ANDROID_PLATFORM = $(ANDROID_PLATFORM)"
+	@echo "ANDROID_HOST = $(ANDROID_HOST)"
+	@echo "ANDROID_TARGET = $(ANDROID_TARGET)"
+	@echo "ANDROID_TOOLCHAIN = $(ANDROID_TOOLCHAIN)"
+	@echo "ANDROID_GCC_TOOLCHAIN = $(ANDROID_GCC_TOOLCHAIN)"
+	@echo "ANDROID_LLVM_TOOLCHAIN = $(ANDROID_LLVM_TOOLCHAIN)"
+	@echo "OPENSSL_VERSION = $(OPENSSL_VERSION)"
+	@echo "OPENSSL_URL = $(OPENSSL_URL)"
+	@echo "OPENSSL_OPTIONS = $(OPENSSL_OPTIONS)"
+	@echo "OPENSSL_PREFIX = $(OPENSSL_PREFIX)"
+	@echo "OPENSSL_CFLAGS = $(OPENSSL_CFLAGS)"
+	@echo "OPENSSL_CC = $(OPENSSL_CC)"
+	@echo "OPENSSL_RANLIB = $(OPENSSL_RANLIB)"
 
-setenv-android-x86.sh: setenv-android.sh
-	cp setenv-android.sh setenv-android-x86.sh.tmp
-	sed -i -e 's/_ANDROID_EABI="arm-linux-androideabi-4.8"/_ANDROID_EABI="x86-4.8"/g' setenv-android-x86.sh.tmp
-	sed -i -e 's/_ANDROID_ARCH=arch-arm/_ANDROID_ARCH=arch-x86/g' setenv-android-x86.sh.tmp
-	mv setenv-android-x86.sh.tmp setenv-android-x86.sh
-
-$(OPENSSL_VER).tar.gz:
-	wget https://www.openssl.org/source/$(OPENSSL_VER).tar.gz
-
-armeabi-v7a/lib/libssl.a: setenv-android.sh $(OPENSSL_VER).tar.gz
-	[ -d "$(ANDROID_NDK_ROOT)" ]
-	export ANDROID_NDK_ROOT="$(ANDROID_NDK_ROOT)"; \
-	. ./setenv-android.sh; \
-	( \
-		set -e; \
-		rm -rf $(OPENSSL_VER)/; \
-		tar xzf $(OPENSSL_VER).tar.gz; \
-		rm -rf $(OPENSSL_VER)-armeabi-v7a/ \
-	) && \
-	mv $(OPENSSL_VER) $(OPENSSL_VER)-armeabi-v7a && \
-	cd $(OPENSSL_VER)-armeabi-v7a && \
-	perl -pi -e 's/install: all install_docs install_sw/install: install_docs install_sw/g' Makefile.org && \
-	./config shared -no-ssl2 -no-ssl3 -no-comp -no-hw -no-engine --openssldir="`pwd`/../armeabi-v7a" && \
-	make depend && \
-	make all && \
-	make install CC=$${ANDROID_TOOLCHAIN}/arm-linux-androideabi-gcc RANLIB=$${ANDROID_TOOLCHAIN}/arm-linux-androideabi-ranlib
-
-x86/lib/libssl.a: setenv-android-x86.sh $(OPENSSL_VER).tar.gz
-	[ -d "$(ANDROID_NDK_ROOT)" ]
-	export ANDROID_NDK_ROOT="$(ANDROID_NDK_ROOT)"; \
-	. ./setenv-android-x86.sh; \
-	( \
-		set -e; \
-		rm -rf $(OPENSSL_VER)/; \
-		tar xzf $(OPENSSL_VER).tar.gz; \
-		rm -rf $(OPENSSL_VER)-x86/ \
-	) && \
-	mv $(OPENSSL_VER) $(OPENSSL_VER)-x86 && \
-	cd $(OPENSSL_VER)-x86 && \
-	perl -pi -e 's/install: all install_docs install_sw/install: install_docs install_sw/g' Makefile.org && \
-	./config shared -no-ssl2 -no-ssl3 -no-comp -no-hw -no-engine --openssldir="`pwd`/../x86" && \
-	make depend && \
-	make all && \
-	make install CC=$${ANDROID_TOOLCHAIN}/i686-linux-android-gcc RANLIB=$${ANDROID_TOOLCHAIN}/i686-linux-android-ranlib
+.PHONY: all clean info

--- a/Build_android/openssl/openssl-1.0.2k.patch
+++ b/Build_android/openssl/openssl-1.0.2k.patch
@@ -1,0 +1,79 @@
+This patch applies several changes that enable OpenSSL 1.0.2k to be built
+for Android using either Clang or GCC toolchains.
+
+An alias for the android-armv7 target, named android-armeabi, is added for
+compatability with the OpenSSL 1.1.0 configuration target names. Support for
+the AARCH64 archicture is also added, as well as targets using the Clang
+compiler.
+
+Clang does not recognize some of the ARM assembly nmenonics that are used in
+OpenSSL. In particular, the 'adrl' pseudo instruction is not supported and
+is replaced with a sequence of instructions implementing its behavior.
+The upstream bug in LLVM can be found here:
+https://llvm.org/bugs/show_bug.cgi?id=24350
+
+diff -Naur org/Configure mod/Configure
+--- org/Configure	2017-01-26 05:22:03.000000000 -0800
++++ mod/Configure	2018-01-11 10:59:39.240298800 -0800
+@@ -474,7 +474,14 @@
+ "android","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-x86","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-armv7","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64","gcc:-march=armv8-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-mips","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-x86-clang","clang:-target i686-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armv7-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64-clang","clang:-target aarch64-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-mips-clang","clang:-target mipsel-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ 
+ #### *BSD [do see comment about ${BSDthreads} above!]
+ "BSD-generic32","gcc:-O3 -fomit-frame-pointer -Wall::${BSDthreads}:::BN_LLONG RC2_CHAR RC4_INDEX DES_INT DES_UNROLL:${no_asm}:dlfcn:bsd-gcc-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+diff -Naur org/crypto/bn/asm/armv4-gf2m.pl mod/crypto/bn/asm/armv4-gf2m.pl
+--- org/crypto/bn/asm/armv4-gf2m.pl	2017-01-26 05:22:03.000000000 -0800
++++ mod/crypto/bn/asm/armv4-gf2m.pl	2018-01-11 10:47:05.118428700 -0800
+@@ -213,8 +213,8 @@
+ .align	5
+ .LNEON:
+ 	ldr		r12, [sp]		@ 5th argument
+-	vmov.32		$a, r2, r1
+-	vmov.32		$b, r12, r3
++	vmov		$a, r2, r1
++	vmov		$b, r12, r3
+ 	vmov.i64	$k48, #0x0000ffffffffffff
+ 	vmov.i64	$k32, #0x00000000ffffffff
+ 	vmov.i64	$k16, #0x000000000000ffff
+diff -Naur org/crypto/sha/asm/sha256-armv4.pl mod/crypto/sha/asm/sha256-armv4.pl
+--- org/crypto/sha/asm/sha256-armv4.pl	2017-01-26 05:22:03.000000000 -0800
++++ mod/crypto/sha/asm/sha256-armv4.pl	2018-01-11 10:47:05.127717500 -0800
+@@ -595,8 +595,17 @@
+ 	adr	$Ktbl,.LARMv8
+ 	sub	$Ktbl,$Ktbl,#.LARMv8-K256
+ # else
++# ifdef __clang__
++	push	{$len}
++	adr     $Ktbl,.LARMv8
++	ldr     $len,=K256
++	sub     $len,$Ktbl,$len
++	sub     $Ktbl,$Ktbl,$len
++	pop     {$len}
++# else
+ 	adrl	$Ktbl,K256
+ # endif
++# endif
+ 	add	$len,$inp,$len,lsl#6	@ len to point at the end of inp
+ 
+ .Loop_v8:
+diff -Naur org/Makefile mod/Makefile
+--- org/Makefile	2017-01-26 05:22:37.000000000 -0800
++++ mod/Makefile	2018-01-11 10:47:05.140214900 -0800
+@@ -534,7 +534,7 @@
+ 	@$(MAKE) SDIRS='$(SDIRS)' clean
+ 	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
+ 
+-install: all install_docs install_sw
++install: install_docs install_sw
+ 
+ install_sw:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \

--- a/Build_android/openssl/openssl-1.0.2l.patch
+++ b/Build_android/openssl/openssl-1.0.2l.patch
@@ -1,0 +1,79 @@
+This patch applies several changes that enable OpenSSL 1.0.2l to be built
+for Android using either Clang or GCC toolchains.
+
+An alias for the android-armv7 target, named android-armeabi, is added for
+compatability with the OpenSSL 1.1.0 configuration target names. Support for
+the AARCH64 archicture is also added, as well as targets using the Clang
+compiler.
+
+Clang does not recognize some of the ARM assembly nmenonics that are used in
+OpenSSL. In particular, the 'adrl' pseudo instruction is not supported and
+is replaced with a sequence of instructions implementing its behavior.
+The upstream bug in LLVM can be found here:
+https://llvm.org/bugs/show_bug.cgi?id=24350
+
+diff -Naur org/Configure mod/Configure
+--- org/Configure	2017-05-25 05:54:38.000000000 -0700
++++ mod/Configure	2018-01-11 12:24:40.489983000 -0800
+@@ -474,7 +474,14 @@
+ "android","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-x86","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-armv7","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64","gcc:-march=armv8-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-mips","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-x86-clang","clang:-target i686-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armv7-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64-clang","clang:-target aarch64-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-mips-clang","clang:-target mipsel-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ 
+ #### *BSD [do see comment about ${BSDthreads} above!]
+ "BSD-generic32","gcc:-O3 -fomit-frame-pointer -Wall::${BSDthreads}:::BN_LLONG RC2_CHAR RC4_INDEX DES_INT DES_UNROLL:${no_asm}:dlfcn:bsd-gcc-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+diff -Naur org/crypto/bn/asm/armv4-gf2m.pl mod/crypto/bn/asm/armv4-gf2m.pl
+--- org/crypto/bn/asm/armv4-gf2m.pl	2017-05-25 05:54:34.000000000 -0700
++++ mod/crypto/bn/asm/armv4-gf2m.pl	2018-01-11 12:24:40.500917800 -0800
+@@ -213,8 +213,8 @@
+ .align	5
+ .LNEON:
+ 	ldr		r12, [sp]		@ 5th argument
+-	vmov.32		$a, r2, r1
+-	vmov.32		$b, r12, r3
++	vmov		$a, r2, r1
++	vmov		$b, r12, r3
+ 	vmov.i64	$k48, #0x0000ffffffffffff
+ 	vmov.i64	$k32, #0x00000000ffffffff
+ 	vmov.i64	$k16, #0x000000000000ffff
+diff -Naur org/crypto/sha/asm/sha256-armv4.pl mod/crypto/sha/asm/sha256-armv4.pl
+--- org/crypto/sha/asm/sha256-armv4.pl	2017-05-25 05:54:34.000000000 -0700
++++ mod/crypto/sha/asm/sha256-armv4.pl	2018-01-11 12:24:40.510993100 -0800
+@@ -595,8 +595,17 @@
+ 	adr	$Ktbl,.LARMv8
+ 	sub	$Ktbl,$Ktbl,#.LARMv8-K256
+ # else
++# ifdef __clang__
++	push	{$len}
++	adr     $Ktbl,.LARMv8
++	ldr     $len,=K256
++	sub     $len,$Ktbl,$len
++	sub     $Ktbl,$Ktbl,$len
++	pop     {$len}
++# else
+ 	adrl	$Ktbl,K256
+ # endif
++# endif
+ 	add	$len,$inp,$len,lsl#6	@ len to point at the end of inp
+ 
+ .Loop_v8:
+diff -Naur org/Makefile mod/Makefile
+--- org/Makefile	2017-05-25 05:55:38.000000000 -0700
++++ mod/Makefile	2018-01-11 12:24:40.524803000 -0800
+@@ -542,7 +542,7 @@
+ 	@$(MAKE) SDIRS='$(SDIRS)' clean
+ 	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
+ 
+-install: all install_docs install_sw
++install: install_docs install_sw
+ 
+ install_sw:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \

--- a/Build_android/openssl/openssl-1.0.2m.patch
+++ b/Build_android/openssl/openssl-1.0.2m.patch
@@ -1,0 +1,79 @@
+This patch applies several changes that enable OpenSSL 1.0.2m to be built
+for Android using either Clang or GCC toolchains.
+
+An alias for the android-armv7 target, named android-armeabi, is added for
+compatability with the OpenSSL 1.1.0 configuration target names. Support for
+the AARCH64 archicture is also added, as well as targets using the Clang
+compiler.
+
+Clang does not recognize some of the ARM assembly nmenonics that are used in
+OpenSSL. In particular, the 'adrl' pseudo instruction is not supported and
+is replaced with a sequence of instructions implementing its behavior.
+The upstream bug in LLVM can be found here:
+https://llvm.org/bugs/show_bug.cgi?id=24350
+
+diff -Naur org/Configure mod/Configure
+--- org/Configure	2017-11-02 07:32:57.000000000 -0700
++++ mod/Configure	2018-01-11 12:43:24.231592100 -0800
+@@ -474,7 +474,14 @@
+ "android","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-x86","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-armv7","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64","gcc:-march=armv8-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-mips","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-x86-clang","clang:-target i686-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armv7-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64-clang","clang:-target aarch64-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-mips-clang","clang:-target mipsel-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ 
+ #### *BSD [do see comment about ${BSDthreads} above!]
+ "BSD-generic32","gcc:-O3 -fomit-frame-pointer -Wall::${BSDthreads}:::BN_LLONG RC2_CHAR RC4_INDEX DES_INT DES_UNROLL:${no_asm}:dlfcn:bsd-gcc-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+diff -Naur org/crypto/bn/asm/armv4-gf2m.pl mod/crypto/bn/asm/armv4-gf2m.pl
+--- org/crypto/bn/asm/armv4-gf2m.pl	2017-11-02 07:32:57.000000000 -0700
++++ mod/crypto/bn/asm/armv4-gf2m.pl	2018-01-11 12:43:24.242241600 -0800
+@@ -213,8 +213,8 @@
+ .align	5
+ .LNEON:
+ 	ldr		r12, [sp]		@ 5th argument
+-	vmov.32		$a, r2, r1
+-	vmov.32		$b, r12, r3
++	vmov		$a, r2, r1
++	vmov		$b, r12, r3
+ 	vmov.i64	$k48, #0x0000ffffffffffff
+ 	vmov.i64	$k32, #0x00000000ffffffff
+ 	vmov.i64	$k16, #0x000000000000ffff
+diff -Naur org/crypto/sha/asm/sha256-armv4.pl mod/crypto/sha/asm/sha256-armv4.pl
+--- org/crypto/sha/asm/sha256-armv4.pl	2017-11-02 07:32:58.000000000 -0700
++++ mod/crypto/sha/asm/sha256-armv4.pl	2018-01-11 12:43:24.252687500 -0800
+@@ -595,8 +595,17 @@
+ 	adr	$Ktbl,.LARMv8
+ 	sub	$Ktbl,$Ktbl,#.LARMv8-K256
+ # else
++# ifdef __clang__
++	push	{$len}
++	adr     $Ktbl,.LARMv8
++	ldr     $len,=K256
++	sub     $len,$Ktbl,$len
++	sub     $Ktbl,$Ktbl,$len
++	pop     {$len}
++# else
+ 	adrl	$Ktbl,K256
+ # endif
++# endif
+ 	add	$len,$inp,$len,lsl#6	@ len to point at the end of inp
+ 
+ .Loop_v8:
+diff -Naur org/Makefile mod/Makefile
+--- org/Makefile	2017-11-02 07:33:46.000000000 -0700
++++ mod/Makefile	2018-01-11 12:43:24.266077400 -0800
+@@ -542,7 +542,7 @@
+ 	@$(MAKE) SDIRS='$(SDIRS)' clean
+ 	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
+ 
+-install: all install_docs install_sw
++install: install_docs install_sw
+ 
+ install_sw:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \

--- a/Build_android/openssl/openssl-1.0.2n.patch
+++ b/Build_android/openssl/openssl-1.0.2n.patch
@@ -1,0 +1,79 @@
+This patch applies several changes that enable OpenSSL 1.0.2n to be built
+for Android using either Clang or GCC toolchains.
+
+An alias for the android-armv7 target, named android-armeabi, is added for
+compatability with the OpenSSL 1.1.0 configuration target names. Support for
+the AARCH64 archicture is also added, as well as targets using the Clang
+compiler.
+
+Clang does not recognize some of the ARM assembly nmenonics that are used in
+OpenSSL. In particular, the 'adrl' pseudo instruction is not supported and
+is replaced with a sequence of instructions implementing its behavior.
+The upstream bug in LLVM can be found here:
+https://llvm.org/bugs/show_bug.cgi?id=24350
+
+diff -Naur org/Configure mod/Configure
+--- org/Configure	2017-12-07 05:16:38.000000000 -0800
++++ mod/Configure	2018-01-11 12:46:25.428402300 -0800
+@@ -474,7 +474,14 @@
+ "android","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-x86","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-armv7","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi","gcc:-march=armv7-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64","gcc:-march=armv8-a -mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "android-mips","gcc:-mandroid -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-x86-clang","clang:-target i686-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:".eval{my $asm=${x86_elf_asm};$asm=~s/:elf/:android/;$asm}.":dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armv7-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-armeabi-clang","clang:-target armv7-none-linux-androideabi --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${armv4_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android64-aarch64-clang","clang:-target aarch64-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -fomit-frame-pointer -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${aarch64_asm}:linux64:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"android-mips-clang","clang:-target mipsel-none-linux-android --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) --sysroot=\$(CROSS_SYSROOT) -I\$(ANDROID_DEV)/include -B\$(ANDROID_DEV)/lib -O3 -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${mips32_asm}:o32:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ 
+ #### *BSD [do see comment about ${BSDthreads} above!]
+ "BSD-generic32","gcc:-O3 -fomit-frame-pointer -Wall::${BSDthreads}:::BN_LLONG RC2_CHAR RC4_INDEX DES_INT DES_UNROLL:${no_asm}:dlfcn:bsd-gcc-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+diff -Naur org/crypto/bn/asm/armv4-gf2m.pl mod/crypto/bn/asm/armv4-gf2m.pl
+--- org/crypto/bn/asm/armv4-gf2m.pl	2017-12-07 05:16:38.000000000 -0800
++++ mod/crypto/bn/asm/armv4-gf2m.pl	2018-01-11 12:46:25.439078400 -0800
+@@ -213,8 +213,8 @@
+ .align	5
+ .LNEON:
+ 	ldr		r12, [sp]		@ 5th argument
+-	vmov.32		$a, r2, r1
+-	vmov.32		$b, r12, r3
++	vmov		$a, r2, r1
++	vmov		$b, r12, r3
+ 	vmov.i64	$k48, #0x0000ffffffffffff
+ 	vmov.i64	$k32, #0x00000000ffffffff
+ 	vmov.i64	$k16, #0x000000000000ffff
+diff -Naur org/crypto/sha/asm/sha256-armv4.pl mod/crypto/sha/asm/sha256-armv4.pl
+--- org/crypto/sha/asm/sha256-armv4.pl	2017-12-07 05:16:38.000000000 -0800
++++ mod/crypto/sha/asm/sha256-armv4.pl	2018-01-11 12:46:25.448917200 -0800
+@@ -595,8 +595,17 @@
+ 	adr	$Ktbl,.LARMv8
+ 	sub	$Ktbl,$Ktbl,#.LARMv8-K256
+ # else
++# ifdef __clang__
++	push	{$len}
++	adr     $Ktbl,.LARMv8
++	ldr     $len,=K256
++	sub     $len,$Ktbl,$len
++	sub     $Ktbl,$Ktbl,$len
++	pop     {$len}
++# else
+ 	adrl	$Ktbl,K256
+ # endif
++# endif
+ 	add	$len,$inp,$len,lsl#6	@ len to point at the end of inp
+ 
+ .Loop_v8:
+diff -Naur org/Makefile mod/Makefile
+--- org/Makefile	2017-12-07 05:19:38.000000000 -0800
++++ mod/Makefile	2018-01-11 12:46:25.462308400 -0800
+@@ -542,7 +542,7 @@
+ 	@$(MAKE) SDIRS='$(SDIRS)' clean
+ 	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
+ 
+-install: all install_docs install_sw
++install: install_docs install_sw
+ 
+ install_sw:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \

--- a/Build_android/openssl/openssl-1.1.0g.patch
+++ b/Build_android/openssl/openssl-1.1.0g.patch
@@ -1,0 +1,71 @@
+This patch applies several changes that enable OpenSSL 1.1.0g to be built
+for Android using either Clang or GCC toolchains.
+
+diff -Naur org/Configurations/10-main.conf mod/Configurations/10-main.conf
+--- org/Configurations/10-main.conf	2017-11-02 07:29:01.000000000 -0700
++++ mod/Configurations/10-main.conf	2018-01-11 13:13:46.858989500 -0800
+@@ -913,12 +913,24 @@
+         cflags           => add(picker(default => "-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack")),
+         bin_cflags       => "-pie",
+     },
++    "android-clang" => {
++        inherit_from     => [ "linux-generic32" ],
++        cc               => "clang",
++        cflags           => add(picker(default => "-fPIC --sysroot=\$(CROSS_SYSROOT) --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Qunused-arguments -Wa,--noexecstack")),
++    },
+     "android-x86" => {
+         inherit_from     => [ "android", asm("x86_asm") ],
+         cflags           => add(picker(release => "-fomit-frame-pointer")),
+         bn_ops           => "BN_LLONG",
+         perlasm_scheme   => "android",
+     },
++    "android-x86-clang" => {
++        inherit_from     => [ "android-clang", asm("x86_asm") ],
++        cflags           => add(picker(default => "-target i686-none-linux-android",
++                                       release => "-fomit-frame-pointer")),
++        bn_ops           => "BN_LLONG",
++        perlasm_scheme   => "android",
++    },
+     ################################################################
+     # Contemporary Android applications can provide multiple JNI
+     # providers in .apk, targeting multiple architectures. Among
+@@ -943,20 +955,38 @@
+     "android-armeabi" => {
+         inherit_from     => [ "android", asm("armv4_asm") ],
+     },
++    "android-armeabi-clang" => {
++        inherit_from     => [ "android-clang", asm("armv4_asm") ],
++        cflags           => add("-target armv7-none-linux-androideabi"),
++    },
+     "android-mips" => {
+         inherit_from     => [ "android", asm("mips32_asm") ],
+         perlasm_scheme   => "o32",
+     },
+-
++    "android-mips-clang" => {
++        inherit_from     => [ "android-clang", asm("mips32_asm") ],
++        cflags           => add("-target mipsel-none-linux-android"),
++        perlasm_scheme   => "o32",
++    },
+     "android64" => {
+         inherit_from     => [ "linux-generic64" ],
+         cflags           => add(picker(default => "-mandroid -fPIC --sysroot=\$(CROSS_SYSROOT) -Wa,--noexecstack")),
+         bin_cflags       => "-pie",
+     },
++    "android64-clang" => {
++        inherit_from     => [ "linux-generic64" ],
++        cc               => "clang",
++        cflags           => add(picker(default => "-fPIC --sysroot=\$(CROSS_SYSROOT) --gcc-toolchain=\$(ANDROID_GCC_TOOLCHAIN) -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Qunused-arguments -Wa,--noexecstack")),
++    },
+     "android64-aarch64" => {
+         inherit_from     => [ "android64", asm("aarch64_asm") ],
+         perlasm_scheme   => "linux64",
+     },
++    "android64-aarch64-clang" => {
++        inherit_from     => [ "android64-clang", asm("aarch64_asm") ],
++        cflags           => add("-target aarch64-none-linux-android"),
++        perlasm_scheme   => "linux64",
++    },
+ 
+ #### *BSD
+     "BSD-generic32" => {


### PR DESCRIPTION
The root Makefile for building OpenSSL has been rewritten, merging
the behavior previously found in the external setenv-android.sh
shell script, with the following numerous changes and additions to
allow for more varied build configurations:

- Added support for building with the Clang/LLVM toolchain instead
  of GCC.
- Added support for more recent Android NDK releases, including
  r10e, r11c, r12b, r13b, and r15c.
- Added support for AARCH64 targets.
- Added support for more OpenSSL releases, with patch files for
  OpenSSL 1.0.2k through 1.0.2n and preliminary support for
  OpenSSL 1.1.0g to ensure forward compatibility.
- Most of the configuration variables in relation to Android now
  follow the same naming scheme and values as CMake.
- Exposed more configuration options as user overridable variables.
- The Makefile must now be invoked once per build target, it no
  longer builds libraries for both armv7 and x86. This simplifies the
  build rules in the Makefile.

The default build configuration for OpenSSL remains the same as
before, with GCC 4.8 as the toolchain, Android-18 as the API level
and OpenSSL 1.0.2k as the OpenSSL release. At a later date,
configure.sh can be updated with additional command line
options to further expose the new features.