### PR TITLE
http_version::from_string argument is now std::string

### DIFF
--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -659,7 +659,7 @@ will_deref_and_erase_t asio_server_connection::handle_http_line(const boost::sys
         std::string http_version = http_path_and_version.substr(http_path_and_version.size() - VersionPortionSize + 1, VersionPortionSize - 2);
 
         auto m_request_impl = m_request._get_impl().get();
-        web::http::http_version parsed_version = web::http::http_version::from_string(utility::conversions::to_string_t(http_version));
+        web::http::http_version parsed_version = web::http::http_version::from_string(http_version);
         m_request_impl->_set_http_version(parsed_version);
 
         // if HTTP version is 1.0 then disable pipelining


### PR DESCRIPTION
Fix to work with commit 1e4717e5aefb080bfc3edd3b9d6ca6e2546c0111. (Follow up to #677. )