### PR TITLE
Disable cert revocation check if cert validation is disabled

### DIFF
--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -667,7 +667,7 @@ protected:
         }
 
         // Enable the certificate revocation check
-        if (m_secure)
+        if (m_secure && client_config().validate_certificates())
         {
             DWORD dwEnableSSLRevocOpt = WINHTTP_ENABLE_SSL_REVOCATION;
             if (!WinHttpSetOption(winhttp_context->m_request_handle, WINHTTP_OPTION_ENABLE_FEATURE, &dwEnableSSLRevocOpt, sizeof(dwEnableSSLRevocOpt)))


### PR DESCRIPTION
This addresses an issue described in #664. It makes it so that certificate revocation is not checked if certificate validation is disabled on http_client_config. Previously there was no way to disable this functionality. 