### PR TITLE
Don't use the ``U()`` preprocessor macro in public headers

### DIFF
--- a/Release/include/cpprest/details/basic_types.h
+++ b/Release/include/cpprest/details/basic_types.h
@@ -80,6 +80,9 @@ typedef std::stringstream stringstream_t;
 #endif // endif _UTF16_STRINGS
 
 #ifndef _TURN_OFF_PLATFORM_STRING
+// The 'U' macro can be used to create a string or character literal of the platform type, i.e. utility::char_t.
+// If you are using a library causing conflicts with 'U' macro, it can be turned off by defining the macro
+// '_TURN_OFF_PLATFORM_STRING' before including the C++ REST SDK header files, and e.g. use '_XPLATSTR' instead.
 #define U(x) _XPLATSTR(x)
 #endif // !_TURN_OFF_PLATFORM_STRING
 

--- a/Release/include/cpprest/details/http_helpers.h
+++ b/Release/include/cpprest/details/http_helpers.h
@@ -58,11 +58,11 @@ namespace details
 
             static compression_algorithm to_compression_algorithm(const utility::string_t& alg)
             {
-                if (U("gzip") == alg)
+                if (_XPLATSTR("gzip") == alg)
                 {
                     return compression_algorithm::gzip;
                 }
-                else if (U("deflate") == alg)
+                else if (_XPLATSTR("deflate") == alg)
                 {
                     return compression_algorithm::deflate;
                 }


### PR DESCRIPTION
…in order that SDK clients can build with ``_TURN_OFF_PLATFORM_STRING`` defined.

There are currently many instances of ``U()`` in src, samples and tests\functional, that mean it's not currently possible to build the SDK itself or many of the samples or tests with ``_TURN_OFF_PLATFORM_STRING`` defined. This PR doesn't address that.

 Fixes #692.
