### PR TITLE
Add support for cert-pinning on Windows and Mac.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -35,6 +35,7 @@ Gery Vessere (gery@vessere.com)
 Cisco Systems
 Gergely Lukacsy (glukacsy)
 Chris Deering (deeringc)
+Chris O'Gorman (chogorma)
 
 Ocedo GmbH
 Henning Pfeiffer (megaposer)

--- a/Release/include/cpprest/certificate_info.h
+++ b/Release/include/cpprest/certificate_info.h
@@ -1,0 +1,48 @@
+/***
+* ==++==
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* ==--==
+* =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+*
+* Certificate info
+*
+* For the latest on this and related APIs, please see: https://github.com/Microsoft/cpprestsdk
+*
+* =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+****/
+
+#pragma once
+
+#include <vector>
+#include <string>
+
+namespace web { namespace http { namespace client {
+
+    using CertificateChain = std::vector<std::vector<unsigned char>>;
+
+    struct certificate_info
+    {
+        CertificateChain certificate_chain;
+        std::string host_name;
+        long certificate_error{ 0 };
+        bool verified{ false };
+
+        certificate_info(const std::string host) : host_name(host) {};
+        certificate_info(const std::string host, CertificateChain chain, long error = 0) : host_name(host), certificate_chain(chain), certificate_error(error) {};
+    };
+
+    using CertificateChainFunction = std::function<bool(const std::shared_ptr<certificate_info> certificate_Info)>;
+
+}}}

--- a/Release/include/cpprest/details/x509_cert_utilities.h
+++ b/Release/include/cpprest/details/x509_cert_utilities.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <string>
+#include "cpprest/certificate_info.h"
 
 #if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || (defined(_WIN32)  && !defined(__cplusplus_winrt) && !defined(_M_ARM) && !defined(CPPREST_EXCLUDE_WEBSOCKETS))
 
@@ -35,6 +36,11 @@
 
 namespace web { namespace http { namespace client { namespace details {
 
+using namespace utility;
+
+
+bool is_end_certificate_in_chain(boost::asio::ssl::verify_context &verifyCtx);
+
 /// <summary>
 /// Using platform specific APIs verifies server certificate.
 /// Currently implemented to work on iOS, Android, and OS X.
@@ -42,7 +48,11 @@ namespace web { namespace http { namespace client { namespace details {
 /// <param name="verifyCtx">Boost.ASIO context to get certificate chain from.</param>
 /// <param name="hostName">Host name from the URI.</param>
 /// <returns>True if verification passed and server can be trusted, false otherwise.</returns>
-bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName);
+bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context &verifyCtx, const std::string &hostName, const CertificateChainFunction& func = nullptr);
+
+bool verify_X509_cert_chain(const std::vector<std::string> &certChain, const std::string &hostName, const CertificateChainFunction& func = nullptr);
+
+std::vector<std::vector<unsigned char>> get_X509_cert_chain_encoded_data(boost::asio::ssl::verify_context &verifyCtx);
 
 }}}}
 

--- a/Release/include/cpprest/oauth2.h
+++ b/Release/include/cpprest/oauth2.h
@@ -16,6 +16,7 @@
 #define _CASA_OAUTH2_H
 
 #include "cpprest/http_msg.h"
+#include "cpprest/certificate_info.h"
 #include "cpprest/details/web_utilities.h"
 
 namespace web
@@ -216,7 +217,8 @@ public:
                 m_implicit_grant(false),
                 m_bearer_auth(true),
                 m_http_basic_auth(true),
-                m_access_token_key(details::oauth2_strings::access_token)
+                m_access_token_key(details::oauth2_strings::access_token),
+                m_certificate_chain_callback([](const std::shared_ptr<web::http::client::certificate_info>&)->bool { return true; })
     {}
 
     /// <summary>
@@ -467,6 +469,17 @@ public:
     /// </summary>
     void set_user_agent(utility::string_t user_agent) { m_user_agent = std::move(user_agent); }
 
+    /// <summary>
+    /// Set the certificate chain callback to be used by the http client.
+    /// </summary>
+    void set_user_certificate_chain_callback(const web::http::client::CertificateChainFunction& callback) { m_certificate_chain_callback = callback; }
+
+    /// <summary>
+    /// Get the cert chain callback.
+    /// </summary>
+    /// <returns>A reference to cert chain callback user by the client.</returns>
+    const web::http::client::CertificateChainFunction& user_certificate_chain_callback() { return m_certificate_chain_callback; }
+
 private:
     friend class web::http::client::http_client_config;
     friend class web::http::oauth2::details::oauth2_handler;
@@ -514,6 +527,8 @@ private:
     oauth2_token m_token;
 
     utility::nonce_generator m_state_generator;
+
+    web::http::client::CertificateChainFunction m_certificate_chain_callback;
 };
 
 } // namespace web::http::oauth2::experimental

--- a/Release/src/http/client/http_client_impl.h
+++ b/Release/src/http/client/http_client_impl.h
@@ -88,6 +88,8 @@ public:
     // Registration for cancellation notification if enabled.
     pplx::cancellation_token_registration m_cancellationRegistration;
 
+    bool m_certificate_chain_verification_failed{ false };
+
 protected:
 
     request_context(const std::shared_ptr<_http_client_communicator> &client, const http_request &request);

--- a/Release/src/http/oauth/oauth2.cpp
+++ b/Release/src/http/oauth/oauth2.cpp
@@ -131,6 +131,7 @@ pplx::task<void> oauth2_config::_request_token(uri_builder& request_body_ub)
 	// configure proxy
 	http_client_config config;
 	config.set_proxy(m_proxy);
+    config.set_user_certificate_chain_callback(m_certificate_chain_callback);
 
     http_client token_client(token_endpoint(), config);
 

--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -196,6 +196,8 @@ public:
 #endif
                 sslContext->set_verify_callback([this](bool preverified, boost::asio::ssl::verify_context &verifyCtx)
                 {
+                    using namespace web::http::client::details;
+
 #if defined(__APPLE__) || (defined(ANDROID) || defined(__ANDROID__)) || defined(_WIN32)
                     // On OS X, iOS, and Android, OpenSSL doesn't have access to where the OS
                     // stores keychains. If OpenSSL fails we will doing verification at the
@@ -207,11 +209,30 @@ public:
                     }
                     if(m_openssl_failed)
                     {
-                        return http::client::details::verify_cert_chain_platform_specific(verifyCtx, utility::conversions::to_utf8string(m_uri.host()));
+
+                        if (!http::client::details::is_end_certificate_in_chain(verifyCtx))
+                        {
+                            // Continue until we get the end certificate.
+                            return true;
+                        }
+
+                        auto chainFunc = [this](const std::shared_ptr<http::client::certificate_info>& cert_info) {
+                            return m_config.invoke_certificate_chain_callback(cert_info);
+                        };
+
+                        return http::client::details::verify_cert_chain_platform_specific(verifyCtx, utility::conversions::to_utf8string(m_uri.host()), chainFunc);
                     }
 #endif
                     boost::asio::ssl::rfc2818_verification rfc2818(utility::conversions::to_utf8string(m_uri.host()));
-                    return rfc2818(preverified, verifyCtx);
+                    if (!rfc2818(preverified, verifyCtx))
+                    {
+                        return false;
+                    }
+
+                    auto info = std::make_shared<http::client::certificate_info>(utility::conversions::to_utf8string(m_uri.host()), get_X509_cert_chain_encoded_data(verifyCtx));
+                    info->verified = true;
+
+                    return m_config.invoke_certificate_chain_callback(info);
                 });
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)


### PR DESCRIPTION
Pull request for the solution we ended up using from the first PR: 
https://github.com/Microsoft/cpprestsdk/pull/135

Again, this is a preliminary pull request to see if you guys are happy to add this to Casablanca.

Added a callback that will return the certificate_info with the cert chain to the consumer.

The certificate_info will contain:
1. The encoded data of each certificate in the chain up to the root certificate (if the OS can build the full chain).
2. The host name of the request.
3. The error code for the current status of the certificate chain.
4. The OS verified status of the chain.

Using this approach we leave the validation of the full certificate chain up to the consumer, so Casablanca does not have to support managing different types of certificate lists for the consumer to do cert-pinning.

The consumer can then use OpenSSL (Or whatever they want) to import the certificate chain and they will then decide on whether to accept or reject the connection.

Current changes are for Windows & Mac.