### PR TITLE
fix template whitespace syntax

### DIFF
--- a/Release/include/cpprest/details/web_utilities.h
+++ b/Release/include/cpprest/details/web_utilities.h
@@ -33,7 +33,7 @@ class zero_memory_deleter
 public:
     _ASYNCRTIMP void operator()(::utility::string_t *data) const;
 };
-typedef std::unique_ptr<::utility::string_t, zero_memory_deleter> plaintext_string;
+typedef std::unique_ptr< ::utility::string_t, zero_memory_deleter> plaintext_string;
 
 #if defined(_WIN32) && !defined(CPPREST_TARGET_XP)
 #if defined(__cplusplus_winrt)

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -757,7 +757,7 @@ public:
 
 private:
 
-    std::shared_ptr<::web::http::client::http_pipeline> m_pipeline;
+    std::shared_ptr< ::web::http::client::http_pipeline> m_pipeline;
 };
 
 namespace details {

--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -301,7 +301,7 @@ public:
         /// <param name="fields">Field names associated with JSON values</param>
         /// <param name="keep_order">Whether to preserve the original order of the fields</param>
         /// <returns>A non-empty JSON object value</returns>
-        static _ASYNCRTIMP json::value __cdecl object(std::vector<std::pair<::utility::string_t, value>> fields, bool keep_order = false);
+        static _ASYNCRTIMP json::value __cdecl object(std::vector<std::pair< ::utility::string_t, value>> fields, bool keep_order = false);
 
         /// <summary>
         /// Creates an empty JSON array

--- a/Release/include/cpprest/ws_client.h
+++ b/Release/include/cpprest/ws_client.h
@@ -184,7 +184,7 @@ public:
     /// <returns>Vector of all the subprotocols </returns>
     /// <remarks>If you want all the subprotocols in a comma separated string
     /// they can be directly looked up in the headers using 'Sec-WebSocket-Protocol'.</remarks>
-    _ASYNCRTIMP std::vector<::utility::string_t> subprotocols() const;
+    _ASYNCRTIMP std::vector< ::utility::string_t> subprotocols() const;
 	
     /// <summary>
     /// Gets the server certificate validation property.


### PR DESCRIPTION
Some files don't have a space inbetween the '<' and '::' charachters, which
will cause build failures on older toolchains. Adding a space inbetween these
two characters fixes the issue.

See http://autobuild.buildroot.net/results/797a9b5fdf6ab0f16f2249324b48292dfab61d9f/build-end.log
for more information.