### PR TITLE
Fix a build problem on Clang.

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -47,7 +47,7 @@
 #include <unordered_set>
 #include <memory>
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 #define AND_CAPTURE_MEMBER_FUNCTION_POINTERS


### PR DESCRIPTION
AND_CAPTURE_MEMBER_FUNCTION_POINTERS workaround had a check for GCC, but did not exclude Clang.  Clang has a fake GCC version of 4.2, thus caused problems.