### PR TITLE
Set the default open() O_CREAT file permissions to 666

### DIFF
--- a/Release/src/streams/fileio_posix.cpp
+++ b/Release/src/streams/fileio_posix.cpp
@@ -160,7 +160,7 @@ bool _open_fsb_str(_filestream_callback *callback, const char *filename, std::io
             cmode |= O_CREAT;
         }
 
-        int f = open(name.c_str(), cmode, 0600);
+        int f = open(name.c_str(), cmode, 0666);
 
         _finish_create(f, callback, mode, prot);
     });


### PR DESCRIPTION
This changes the default file creation permissions on unix to 666. This allows for more control by system administrators using `umask`. Along with a default umask of `022` (on most systems) files would be created with permissions `0644`.