### PR TITLE
Require at least CMake 3.1 due to use of target_sources

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW) # use MACOSX_RPATH
 endif()


### PR DESCRIPTION
target_sources() is only available since this version and this avoids

CMake Error at src/CMakeLists.txt:92 (target_sources):
  Unknown CMake command "target_sources".

when using CMake 3.0, for example.

Closes #633.