### PR TITLE
Fix for compilation with MSVC permissive-

### DIFF
--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -1747,7 +1747,7 @@ public:
 
     static pplx::task<std::wstring> parse(streams::streambuf<CharType> buffer)
     {
-        return _parse_input<std::basic_string<char>,std::basic_string<wchar_t>>(buffer, _accept_char, _extract_result);
+        return base::_parse_input<std::basic_string<char>,std::basic_string<wchar_t>>(buffer, _accept_char, _extract_result);
     }
 
 private:


### PR DESCRIPTION
Related Visual Studio issue:
https://developercommunity.visualstudio.com/content/problem/238445/template-class-cant-access-protected-member-when-c.html

Problem is with code compiling with /permissive-, so the template functions are affected by this issue.