### PR TITLE
Delete open() from _http_client_communicator

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -400,8 +400,6 @@ public:
 
     void send_request(const std::shared_ptr<request_context> &request_ctx) override;
 
-    unsigned long open() override { return 0; }
-
     void release_connection(std::shared_ptr<asio_connection>& conn)
     {
         m_pool->release(conn);

--- a/Release/src/http/client/http_client_impl.h
+++ b/Release/src/http/client/http_client_impl.h
@@ -129,10 +129,11 @@ private:
     http_client_config m_client_config;
 
     // Wraps opening the client around sending a request.
-    void send_request_async_impl(const std::shared_ptr<request_context> &request);
+    void async_send_request_impl(const std::shared_ptr<request_context> &request);
 
     // Queue used to guarantee ordering of requests, when applicable.
     std::queue<std::shared_ptr<request_context>> m_requests_queue;
+    bool m_outstanding;
 };
 
 /// <summary>

--- a/Release/src/http/client/http_client_impl.h
+++ b/Release/src/http/client/http_client_impl.h
@@ -117,30 +117,22 @@ public:
 protected:
     _http_client_communicator(http::uri&& address, http_client_config&& client_config);
 
-    // Method to open client.
-    virtual unsigned long open() = 0;
-
     // HTTP client implementations must implement send_request.
     virtual void send_request(_In_ const std::shared_ptr<request_context> &request) = 0;
 
     // URI to connect to.
     const http::uri m_uri;
 
+    pplx::extensibility::critical_section_t m_client_lock;
 private:
 
     http_client_config m_client_config;
 
-    std::atomic<bool> m_opened;
-
-    pplx::extensibility::critical_section_t m_open_lock;
-
     // Wraps opening the client around sending a request.
-    void open_and_send_request_async(const std::shared_ptr<request_context> &request);
-    void open_and_send_request(const std::shared_ptr<request_context> &request);
+    void send_request_async_impl(const std::shared_ptr<request_context> &request);
 
     // Queue used to guarantee ordering of requests, when applicable.
     std::queue<std::shared_ptr<request_context>> m_requests_queue;
-    int m_scheduled;
 };
 
 /// <summary>

--- a/Release/src/http/client/http_client_winrt.cpp
+++ b/Release/src/http/client/http_client_winrt.cpp
@@ -378,12 +378,6 @@ public:
 
 protected:
 
-    // Method to open client.
-    unsigned long open()
-    {
-        return 0;
-    }
-
     // Start sending request.
     void send_request(_In_ const std::shared_ptr<request_context> &request)
     {


### PR DESCRIPTION
… and move its functionality into WinHTTP, as that is the only backend using that thing.