### PR TITLE
Fix another clang build failure (Fixes: #747)

### DIFF
--- a/Release/include/pplx/pplxlinux.h
+++ b/Release/include/pplx/pplxlinux.h
@@ -240,7 +240,11 @@ namespace platform
     {
     public:
         _PPLXIMP virtual void schedule( TaskProc_t proc, _In_ void* param);
+#if defined(__APPLE__)
+    virtual ~apple_scheduler() {}
+#else
     virtual ~linux_scheduler() {}
+#endif
     };
 
 } // namespace details

--- a/Release/include/pplx/pplxlinux.h
+++ b/Release/include/pplx/pplxlinux.h
@@ -240,6 +240,7 @@ namespace platform
     {
     public:
         _PPLXIMP virtual void schedule( TaskProc_t proc, _In_ void* param);
+    virtual ~linux_scheduler() {}
     };
 
 } // namespace details


### PR DESCRIPTION
===>  Building for cpprestsdk-2.9.1_5
[1/161] /usr/local/libexec/ccache/c++  -Dcpprest_EXPORTS -Iinclude -isystem /usr/local/include -isystem libs/websocketpp -Isrc/../include -Isrc/pch -O2 -pipe -fstack-protector -fno-strict-aliasing -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration -std=c++11 -fno-strict-aliasing -O2 -pipe -fstack-protector -fno-strict-aliasing -fPIC   -Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls -Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs -Werror -pedantic -MD -MT src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o -MF src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o.d -o src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o -c src/pplx/pplx.cpp
FAILED: src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o
/usr/local/libexec/ccache/c++  -Dcpprest_EXPORTS -Iinclude -isystem /usr/local/include -isystem libs/websocketpp -Isrc/../include -Isrc/pch -O2 -pipe -fstack-protector -fno-strict-aliasing -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration -std=c++11 -fno-strict-aliasing -O2 -pipe -fstack-protector -fno-strict-aliasing -fPIC   -Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls -Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs -Werror -pedantic -MD -MT src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o -MF src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o.d -o src/CMakeFiles/cpprest.dir/pplx/pplx.cpp.o -c src/pplx/pplx.cpp
In file included from src/pplx/pplx.cpp:14:
In file included from src/pch/stdafx.h:23:
In file included from include/cpprest/details/basic_types.h:16:
In file included from /usr/include/c++/v1/string:477:
In file included from /usr/include/c++/v1/string_view:176:
In file included from /usr/include/c++/v1/__string:56:
In file included from /usr/include/c++/v1/algorithm:643:
/usr/include/c++/v1/memory:3656:5: error: destructor called on non-final 'pplx::details::linux_scheduler' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
    __data_.second().~_Tp();
    ^
/usr/include/c++/v1/memory:3612:5: note: in instantiation of member function 'std::__1::__shared_ptr_emplace<pplx::details::linux_scheduler, std::__1::allocator<pplx::details::linux_scheduler> >::__on_zero_shared' requested here
    __shared_ptr_emplace(_Alloc __a)
    ^
/usr/include/c++/v1/memory:4277:26: note: in instantiation of member function 'std::__1::__shared_ptr_emplace<pplx::details::linux_scheduler, std::__1::allocator<pplx::details::linux_scheduler> >::__shared_ptr_emplace' requested here
    ::new(__hold2.get()) _CntrlBlk(__a2, _VSTD::forward<_Args>(__args)...);
                         ^
/usr/include/c++/v1/memory:4656:29: note: in instantiation of function template specialization 'std::__1::shared_ptr<pplx::details::linux_scheduler>::make_shared<>' requested here
    return shared_ptr<_Tp>::make_shared(_VSTD::forward<_Args>(__args)...);
                            ^
src/pplx/pplx.cpp:94:40: note: in instantiation of function template specialization 'std::__1::make_shared<pplx::details::linux_scheduler>' requested here
                    m_scheduler = std::make_shared< ::pplx::default_scheduler_t>();
                                       ^
/usr/include/c++/v1/memory:3656:23: note: qualify call to silence this warning
    __data_.second().~_Tp();
                      ^
1 error generated.