### PR TITLE
Fix default installation path for cmake files

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -18,7 +18,7 @@ enable_testing()
 set(WERROR ON CACHE BOOL "Treat Warnings as Errors.")
 set(CPPREST_EXCLUDE_WEBSOCKETS OFF CACHE BOOL "Exclude websockets functionality.")
 set(CPPREST_EXCLUDE_COMPRESSION OFF CACHE BOOL "Exclude compression functionality.")
-set(CPPREST_EXPORT_DIR lib/cpprestsdk CACHE STRING "Directory to install CMake config files.")
+set(CPPREST_EXPORT_DIR cmake CACHE STRING "Directory to install CMake config files.")
 set(CPPREST_INSTALL_HEADERS ON CACHE BOOL "Install header files.")
 set(CPPREST_INSTALL ON CACHE BOOL "Add install commands.")
 

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -262,12 +262,12 @@ if(CPPREST_INSTALL)
 
   install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/cpprestsdk-config.cmake"
-    DESTINATION ${CPPREST_EXPORT_DIR}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPPREST_EXPORT_DIR}
   )
   install(
     EXPORT cpprestsdk-targets
     FILE cpprestsdk-targets.cmake
     NAMESPACE cpprestsdk::
-    DESTINATION ${CPPREST_EXPORT_DIR}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${CPPREST_EXPORT_DIR}
   )
 endif()


### PR DESCRIPTION
After #737 got merged, I think there is still something missing.

Fixup the merge to make cpprest being detected by pkg-config.