### PR TITLE
Allow building with HTTP compression support without WebSockets

### DIFF
--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -75,6 +75,7 @@ if(CPPREST_EXCLUDE_COMPRESSION)
 else()
   cpprest_find_zlib()
   target_link_libraries(cpprest PRIVATE cpprestsdk_zlib_internal)
+  target_compile_definitions(cpprest PRIVATE -DCPPREST_HTTP_COMPRESSION=1)
 endif()
 
 # PPLX component


### PR DESCRIPTION
Currently, even if `CPPREST_EXCLUDE_COMPRESSION` is not set, HTTP compression support is disabled when WebSockets is disabled, even though it appears to only depend on zlib.

This PR allows building the library with HTTP compression without a dependency on OpenSSL and Boost.