### PR TITLE
Enable precompiled headers for test/functional

### DIFF
--- a/Release/tests/functional/http/client/CMakeLists.txt
+++ b/Release/tests/functional/http/client/CMakeLists.txt
@@ -32,6 +32,19 @@ else()
   target_link_libraries(httpclient_test PRIVATE httptest_utilities)
 endif()
 
+if(MSVC)
+  get_target_property(_srcs httpclient_test SOURCES)
+
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+  target_sources(httpclient_test PRIVATE stdafx.cpp)
+  target_compile_options(httpclient_test PRIVATE /Yustdafx.h /Zm200)
+endif()
+
 if(NOT WIN32)
   cpprest_find_boost()
   target_link_libraries(httpclient_test PRIVATE cpprestsdk_boost_internal)

--- a/Release/tests/functional/json/CMakeLists.txt
+++ b/Release/tests/functional/json/CMakeLists.txt
@@ -16,3 +16,16 @@ if(UNIX AND NOT APPLE)
   cpprest_find_boost()
   target_link_libraries(json_test PRIVATE cpprestsdk_boost_internal)
 endif()
+
+if(MSVC)
+  get_target_property(_srcs json_test SOURCES)
+
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+  target_sources(json_test PRIVATE stdafx.cpp)
+  target_compile_options(json_test PRIVATE /Yustdafx.h /Zm200)
+endif()

--- a/Release/tests/functional/pplx/pplx_test/CMakeLists.txt
+++ b/Release/tests/functional/pplx/pplx_test/CMakeLists.txt
@@ -6,3 +6,16 @@ set(SOURCES
 )
 
 add_casablanca_test(pplx_test SOURCES)
+
+if(MSVC)
+  get_target_property(_srcs pplx_test SOURCES)
+
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+  target_sources(pplx_test PRIVATE stdafx.cpp)
+  target_compile_options(pplx_test PRIVATE /Yustdafx.h /Zm200)
+endif()

--- a/Release/tests/functional/streams/CMakeLists.txt
+++ b/Release/tests/functional/streams/CMakeLists.txt
@@ -24,3 +24,16 @@ if(NOT WIN32 OR CPPREST_WEBSOCKETS_IMPL STREQUAL "wspp")
     target_include_directories(streams_test PRIVATE $<TARGET_PROPERTY:cpprestsdk_boost_internal,INTERFACE_INCLUDE_DIRECTORIES>)
   endif()
 endif()
+
+if(MSVC)
+  get_target_property(_srcs streams_test SOURCES)
+
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+  target_sources(streams_test PRIVATE stdafx.cpp)
+  target_compile_options(streams_test PRIVATE /Yustdafx.h /Zm200)
+endif()

--- a/Release/tests/functional/uri/CMakeLists.txt
+++ b/Release/tests/functional/uri/CMakeLists.txt
@@ -12,3 +12,16 @@ set(SOURCES
 )
 
 add_casablanca_test(uri_test SOURCES)
+
+if(MSVC)
+  get_target_property(_srcs uri_test SOURCES)
+
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+  target_sources(uri_test PRIVATE stdafx.cpp)
+  target_compile_options(uri_test PRIVATE /Yustdafx.h /Zm200)
+endif()

--- a/Release/tests/functional/utils/CMakeLists.txt
+++ b/Release/tests/functional/utils/CMakeLists.txt
@@ -13,3 +13,16 @@ add_casablanca_test(utils_test SOURCES)
 if(CMAKE_COMPILER_IS_GNUCXX)
   target_compile_options(utils_test PRIVATE "-Wno-deprecated-declarations")
 endif()
+
+if(MSVC)
+  get_target_property(_srcs utils_test SOURCES)
+
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+  target_sources(utils_test PRIVATE stdafx.cpp)
+  target_compile_options(utils_test PRIVATE /Yustdafx.h /Zm200)
+endif()


### PR DESCRIPTION
Use of precompiled headers is not activated for test projects even though they are all prepared to use pch. This results in longer build times since the precompiled header is now include as "normal", very expensive header.