### PR TITLE
Update brotli compressor/decompressor for API change

### DIFF
--- a/Release/src/http/common/http_compression.cpp
+++ b/Release/src/http/common/http_compression.cpp
@@ -383,7 +383,7 @@ public:
         try
         {
             r.output_bytes_produced =
-                compress(input, input_size, output, output_size, hint, r.input_bytes_processed, &r.done);
+                compress(input, input_size, output, output_size, hint, r.input_bytes_processed, r.done);
         }
         catch (...)
         {
@@ -509,7 +509,7 @@ public:
         try
         {
             r.output_bytes_produced =
-                decompress(input, input_size, output, output_size, hint, r.input_bytes_processed, &r.done);
+                decompress(input, input_size, output, output_size, hint, r.input_bytes_processed, r.done);
         }
         catch (...)
         {


### PR DESCRIPTION
It looks like we missed this in #905.  Builds with -DCPPREST_EXCLUDE_BROTLI=OFF fail with C2664 due to the API change from `bool *` to `bool &`.
