### PR TITLE
Avoid using identifiers reserved by C++ in header guards

### DIFF
--- a/Release/include/cpprest/filestream.h
+++ b/Release/include/cpprest/filestream.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_FILE_STREAMS_H
-#define _CASA_FILE_STREAMS_H
+#ifndef CASA_FILE_STREAMS_H
+#define CASA_FILE_STREAMS_H
 
 #include "cpprest/details/fileio.h"
 #include "cpprest/astreambuf.h"

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_HTTP_CLIENT_H
-#define _CASA_HTTP_CLIENT_H
+#ifndef CASA_HTTP_CLIENT_H
+#define CASA_HTTP_CLIENT_H
 
 #if defined (__cplusplus_winrt)
 #if !defined(__WRL_NO_DEFAULT_LIB__)

--- a/Release/include/cpprest/http_listener.h
+++ b/Release/include/cpprest/http_listener.h
@@ -10,8 +10,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_HTTP_LISTENER_H
-#define _CASA_HTTP_LISTENER_H
+#ifndef CASA_HTTP_LISTENER_H
+#define CASA_HTTP_LISTENER_H
 
 #include <limits>
 #include <functional>

--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_JSON_H
-#define _CASA_JSON_H
+#ifndef CASA_JSON_H
+#define CASA_JSON_H
 
 #include <memory>
 #include <string>

--- a/Release/include/cpprest/oauth1.h
+++ b/Release/include/cpprest/oauth1.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_OAUTH1_H
-#define _CASA_OAUTH1_H
+#ifndef CASA_OAUTH1_H
+#define CASA_OAUTH1_H
 
 #include "cpprest/http_msg.h"
 #include "cpprest/details/web_utilities.h"

--- a/Release/include/cpprest/oauth2.h
+++ b/Release/include/cpprest/oauth2.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_OAUTH2_H
-#define _CASA_OAUTH2_H
+#ifndef CASA_OAUTH2_H
+#define CASA_OAUTH2_H
 
 #include "cpprest/http_msg.h"
 #include "cpprest/details/web_utilities.h"

--- a/Release/include/cpprest/producerconsumerstream.h
+++ b/Release/include/cpprest/producerconsumerstream.h
@@ -13,8 +13,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_PRODUCER_CONSUMER_STREAMS_H
-#define _CASA_PRODUCER_CONSUMER_STREAMS_H
+#ifndef CASA_PRODUCER_CONSUMER_STREAMS_H
+#define CASA_PRODUCER_CONSUMER_STREAMS_H
 
 #include <vector>
 #include <queue>

--- a/Release/include/cpprest/rawptrstream.h
+++ b/Release/include/cpprest/rawptrstream.h
@@ -13,8 +13,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_RAWPTR_STREAMS_H
-#define _CASA_RAWPTR_STREAMS_H
+#ifndef CASA_RAWPTR_STREAMS_H
+#define CASA_RAWPTR_STREAMS_H
 
 #include <vector>
 #include <queue>

--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_STREAMS_H
-#define _CASA_STREAMS_H
+#ifndef CASA_STREAMS_H
+#define CASA_STREAMS_H
 
 #include "cpprest/astreambuf.h"
 #include <iosfwd>

--- a/Release/include/cpprest/uri.h
+++ b/Release/include/cpprest/uri.h
@@ -12,8 +12,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_URI_H
-#define _CASA_URI_H
+#ifndef CASA_URI_H
+#define CASA_URI_H
 
 #include "cpprest/base_uri.h"
 #include "cpprest/uri_builder.h"

--- a/Release/include/cpprest/ws_client.h
+++ b/Release/include/cpprest/ws_client.h
@@ -10,8 +10,8 @@
 ****/
 #pragma once
 
-#ifndef _CASA_WS_CLIENT_H
-#define _CASA_WS_CLIENT_H
+#ifndef CASA_WS_CLIENT_H
+#define CASA_WS_CLIENT_H
 
 #include "cpprest/details/basic_types.h"
 


### PR DESCRIPTION
issue: #14