### PR TITLE
blackjack sample: use vector instead of shared pointer for array

### DIFF
--- a/Release/samples/BlackJack/BlackJack_Server/Table.cpp
+++ b/Release/samples/BlackJack/BlackJack_Server/Table.cpp
@@ -456,8 +456,7 @@ void DealerTable::FillShoe(size_t decks)
     //
     // Stack the decks.
     //
-    std::shared_ptr<int> ss(new int[decks * 52]);
-    auto shoe = ss.get();
+    std::vector<int> shoe(decks * 52);
 
     for (size_t d = 0; d < decks ; d++)
     {


### PR DESCRIPTION
A `new int[]` would need `delete[]` to be cleaned up correctly. Instead a vector can be used to keep the data. The shared pointer is not passed to other scopes and can be avoided easily.