### PR TITLE
Fix incorrect const in reinterpret_cast (#950)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -46,3 +46,6 @@ Trimble
 Tim Boundy (gigaplex)
 
 Rami Abughazaleh (icnocop)
+
+TastenTrick
+Christian Deneke (chris0x44)

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -356,7 +356,7 @@ using UtilCharInternal_t = signed char;
 inline size_t count_utf8_to_utf16(const std::string& s)
 {
     const size_t sSize = s.size();
-    auto sData = reinterpret_cast<const UtilCharInternal_t* const>(s.data());
+    auto const sData = reinterpret_cast<const UtilCharInternal_t*>(s.data());
     size_t result{ sSize };
 
     for (size_t index = 0; index < sSize;)
@@ -441,7 +441,7 @@ utf16string __cdecl conversions::utf8_to_utf16(const std::string &s)
 {
     // Save repeated heap allocations, use the length of resulting sequence.
     const size_t srcSize = s.size();
-    auto srcData = reinterpret_cast<const UtilCharInternal_t* const>(s.data());
+    auto const srcData = reinterpret_cast<const UtilCharInternal_t*>(s.data());
     utf16string dest(count_utf8_to_utf16(s), L'\0');
     utf16string::value_type* const destData = &dest[0];
     size_t destIndex = 0;


### PR DESCRIPTION
This solves the warning causing build failure referred to in https://github.com/Microsoft/cpprestsdk/issues/950 