### PR TITLE
Adds support for OpenSSL 1.1.1

### DIFF
--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -51,7 +51,12 @@ bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context& verif
         return true;
     }
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     STACK_OF(X509)* certStack = X509_STORE_CTX_get_chain(storeContext);
+#else 
+    STACK_OF(X509)* certStack = X509_STORE_CTX_get0_chain(storeContext);
+#endif
+    
     const int numCerts = sk_X509_num(certStack);
     if (numCerts < 0)
     {


### PR DESCRIPTION
Adds support for OpenSSL 1.1.1, given updated websocketpp and boost/asio, at least on macOS and iOS.
(see https://github.com/Microsoft/cpprestsdk/issues/949)