### PR TITLE
Fixes iOS builds and makes it more future proof

### DIFF
--- a/Build_iOS/configure.sh
+++ b/Build_iOS/configure.sh
@@ -11,7 +11,9 @@ fi
 
 ## Configuration
 DEFAULT_BOOST_VERSION=1.67.0
+DEFAULT_OPENSSL_VERSION=1.0.2o
 BOOST_VERSION=${BOOST_VERSION:-${DEFAULT_BOOST_VERSION}}
+OPENSSL_VERSION=${OPENSSL_VERSION:-${DEFAULT_OPENSSL_VERSION}}
 CPPRESTSDK_BUILD_TYPE=${CPPRESTSDK_BUILD_TYPE:-Release}
 
 ############################ No need to edit anything below this line
@@ -48,7 +50,7 @@ if [ ! -e ${ABS_PATH}/openssl/lib/libcrypto.a ]; then
     fi
     pushd ${ABS_PATH}/OpenSSL-for-iPhone
     git checkout 10019638e80e8a8a5fc19642a840d8a69fac7349
-    ./build-libssl.sh
+    ./build-libssl.sh --version=${OPENSSL_VERSION}
     popd
     mkdir -p ${ABS_PATH}/openssl/lib
     if [ -e ${ABS_PATH}/OpenSSL-for-iPhone/bin/iPhoneOS${IOS_SDK_VERSION}-arm64.sdk/include ]

--- a/Build_iOS/configure.sh
+++ b/Build_iOS/configure.sh
@@ -1,54 +1,86 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
-if [ ! -e boost.framework ]
-then
-    git clone https://github.com/faithfracture/Apple-Boost-BuildScript Apple-Boost-BuildScript
-    pushd ./Apple-Boost-BuildScript
-    git checkout 1b94ec2e2b5af1ee036d9559b96e70c113846392
-    BOOST_LIBS="thread chrono filesystem regex system random" ./boost.sh -ios -tvos
-    popd
-    mv Apple-Boost-BuildScript/build/boost/1.67.0/ios/framework/boost.framework .
-    mv boost.framework/Versions/A/Headers boost.headers
-    mkdir -p boost.framework/Versions/A/Headers
-    mv boost.headers boost.framework/Versions/A/Headers/boost
+ABS_PATH="`dirname \"$0\"`"                 # relative
+ABS_PATH="`( cd \"${ABS_PATH}\" && pwd )`"  # absolutized and normalized
+# Make sure that the path to this file exists and can be retrieved!
+if [ -z "${ABS_PATH}" ]; then
+  echo "Could not fetch the ABS_PATH."
+  exit 1
 fi
 
-if [ ! -e openssl/lib/libcrypto.a ]
-then
-    git clone --depth=1 https://github.com/x2on/OpenSSL-for-iPhone.git
-    pushd OpenSSL-for-iPhone
+## Configuration
+DEFAULT_BOOST_VERSION=1.67.0
+BOOST_VERSION=${BOOST_VERSION:-${DEFAULT_BOOST_VERSION}}
+CPPRESTSDK_BUILD_TYPE=${CPPRESTSDK_BUILD_TYPE:-Release}
+
+############################ No need to edit anything below this line
+
+## Set some needed variables
+IOS_SDK_VERSION=`xcrun --sdk iphoneos --show-sdk-version`
+
+## Buildsteps below
+
+## Fetch submodules just in case
+git submodule update --init
+
+## Build Boost
+
+if [ ! -e $ABS_PATH/boost.framework ]; then
+    if [ ! -d "${ABS_PATH}/Apple-Boost-BuildScript" ]; then
+        git clone https://github.com/faithfracture/Apple-Boost-BuildScript ${ABS_PATH}/Apple-Boost-BuildScript
+    fi
+    pushd ${ABS_PATH}/Apple-Boost-BuildScript
+    git checkout 1b94ec2e2b5af1ee036d9559b96e70c113846392
+    BOOST_LIBS="thread chrono filesystem regex system random" ./boost.sh -ios -tvos --boost-version $BOOST_VERSION
+    popd
+    mv ${ABS_PATH}/Apple-Boost-BuildScript/build/boost/${BOOST_VERSION}/ios/framework/boost.framework ${ABS_PATH}
+    mv ${ABS_PATH}/boost.framework/Versions/A/Headers ${ABS_PATH}/boost.headers
+    mkdir -p ${ABS_PATH}/boost.framework/Versions/A/Headers
+    mv ${ABS_PATH}/boost.headers ${ABS_PATH}/boost.framework/Versions/A/Headers/boost
+fi
+
+## Build OpenSSL
+
+if [ ! -e ${ABS_PATH}/openssl/lib/libcrypto.a ]; then
+    if [ ! -d "${ABS_PATH}/OpenSSL-for-iPhone" ]; then
+       git clone --depth=1 https://github.com/x2on/OpenSSL-for-iPhone.git ${ABS_PATH}/OpenSSL-for-iPhone
+    fi
+    pushd ${ABS_PATH}/OpenSSL-for-iPhone
     git checkout 10019638e80e8a8a5fc19642a840d8a69fac7349
     ./build-libssl.sh
     popd
-    mkdir -p openssl/lib
-    if [ -e OpenSSL-for-iPhone/bin/iPhoneOS11.4-arm64.sdk/include ]
+    mkdir -p ${ABS_PATH}/openssl/lib
+    if [ -e ${ABS_PATH}/OpenSSL-for-iPhone/bin/iPhoneOS${IOS_SDK_VERSION}-arm64.sdk/include ]
     then
-        cp -r OpenSSL-for-iPhone/bin/iPhoneOS11.4-arm64.sdk/include openssl
-    elif [ -e OpenSSL-for-iPhone/bin/iPhoneOS12.0-arm64.sdk/include ]
-    then
-        cp -r OpenSSL-for-iPhone/bin/iPhoneOS12.0-arm64.sdk/include openssl
+        cp -r ${ABS_PATH}/OpenSSL-for-iPhone/bin/iPhoneOS${IOS_SDK_VERSION}-arm64.sdk/include ${ABS_PATH}/openssl
     else
         echo 'Could not find OpenSSL for iPhone'
         exit 1
     fi
-    cp OpenSSL-for-iPhone/include/LICENSE openssl
-    lipo -create -output openssl/lib/libssl.a OpenSSL-for-iPhone/bin/iPhone*/lib/libssl.a
-    lipo -create -output openssl/lib/libcrypto.a OpenSSL-for-iPhone/bin/iPhone*/lib/libcrypto.a
+    cp ${ABS_PATH}/OpenSSL-for-iPhone/include/LICENSE ${ABS_PATH}/openssl
+    lipo -create -output ${ABS_PATH}/openssl/lib/libssl.a ${ABS_PATH}/OpenSSL-for-iPhone/bin/iPhone*/lib/libssl.a
+    lipo -create -output ${ABS_PATH}/openssl/lib/libcrypto.a ${ABS_PATH}/OpenSSL-for-iPhone/bin/iPhone*/lib/libcrypto.a
 fi
 
-if [ ! -e ios-cmake/ios.toolchain.cmake ]
-then
-    git clone https://github.com/leetal/ios-cmake
-    pushd ios-cmake
-    git checkout 6b30f4cfeab5567041d38e79507e642056fb9fd4
+## Fetch CMake toolchain
+
+if [ ! -e ${ABS_PATH}/ios-cmake/ios.toolchain.cmake ]; then
+    if [ ! -d "${ABS_PATH}/ios-cmake" ]; then
+        git clone https://github.com/leetal/ios-cmake ${ABS_PATH}/ios-cmake
+    fi
+    pushd ${ABS_PATH}/ios-cmake
+    git checkout 2.1.2
     popd
 fi
 
-mkdir -p build.release.ios
-pushd build.release.ios
-cmake -DCMAKE_BUILD_TYPE=Release ..
+## Build CPPRestSDK
+
+mkdir -p ${ABS_PATH}/build.${CPPRESTSDK_BUILD_TYPE}.ios
+pushd ${ABS_PATH}/build.${CPPRESTSDK_BUILD_TYPE}.ios
+cmake -DCMAKE_BUILD_TYPE=${CPPRESTSDK_BUILD_TYPE} ..
 make
 popd
-echo "===="
-echo "The final library is available in 'build.ios/libcpprest.a'"
+printf "\n\n===================================================================================\n"
+echo ">>>> The final library is available in 'build.${CPPRESTSDK_BUILD_TYPE}.ios/libcpprest.a'"
+printf "===================================================================================\n\n"

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-Contributors should submit an update to this file with a commit in order to receive recognition. Thank you for your contributions. 
+Contributors should submit an update to this file with a commit in order to receive recognition. Thank you for your contributions.
 
 
 List of Contributors
@@ -17,7 +17,7 @@ intercommiura
 halex2005
 simonlep
 jracle
-gandziej 
+gandziej
 adish
 LeonidCSIT
 kreuzerkrieg
@@ -49,3 +49,5 @@ Rami Abughazaleh (icnocop)
 
 TastenTrick
 Christian Deneke (chris0x44)
+
+leetal

--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -116,10 +116,7 @@ set(WARNINGS)
 set(ANDROID_LIBS)
 
 # Platform (not compiler) specific settings
-if(IOS)
-  # The cxx_flags must be reset here, because the ios-cmake toolchain file unfortunately sets "-headerpad_max_install_names" which is not a valid clang flag.
-  set(CMAKE_CXX_FLAGS "-fvisibility=hidden")
-elseif(ANDROID)
+if(ANDROID)
   # These are used in the shared library case
   set(ANDROID_LIBS atomic dl)
 elseif(UNIX) # This includes OSX


### PR DESCRIPTION
This PR fixes the current issues with the iOS builds as well as makes it more future proof. 

I have also added the following:
* Possibility to change OpenSSL version via env-var `OPENSSL_VERSION` (defaults to 1.0.2o)
* Possibility to change Boost version via env-var `BOOST_VERSION` (defaults to 1.67.0)
* Possibility to build debug variants of CPPRestSDK via env-var `CPPRESTSDK_BUILD_TYPE` (defaults to Release)

Fixes #953 