### PR TITLE
Prevent infinite loop during proxy authentication

### DIFF
--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -1723,27 +1723,27 @@ private:
         }
     }
 
-    static utility::string_t get_request_url(HINTERNET hRequestHandle)
+    static std::wstring get_request_url(HINTERNET hRequestHandle)
     {
-        DWORD urlSize{ 0 };
-        if(FALSE == WinHttpQueryOption(hRequestHandle, WINHTTP_OPTION_URL, nullptr, &urlSize) || urlSize == 0)
+        std::wstring url;
+        auto urlSize = static_cast<unsigned long>(url.capacity()) * 2; // use initial small string optimization capacity
+        for (;;)
         {
-            // Ignore 'ERROR_INSUFFICIENT_BUFFER' because it is expected when passing a null 'lpBuffer' to query 'lpdwBufferLength'
-            if (ERROR_INSUFFICIENT_BUFFER != GetLastError())
+            url.resize(urlSize / sizeof(wchar_t));
+            if (WinHttpQueryOption(hRequestHandle, WINHTTP_OPTION_URL, &url[0], &urlSize))
             {
-                return U("");
+                url.resize(wcslen(url.c_str()));
+                return url;
+            }
+
+            const auto lastError = GetLastError();
+            if (lastError != ERROR_INSUFFICIENT_BUFFER || urlSize == 0)
+            {
+                url.clear();
+                url.shrink_to_fit();
+                return url;
             }
         }
-
-        auto urlwchar = new WCHAR[urlSize / sizeof(WCHAR)];
-
-        WinHttpQueryOption(hRequestHandle, WINHTTP_OPTION_URL, (void*)urlwchar, &urlSize);
-
-        utility::string_t url(urlwchar);
-
-        delete[] urlwchar;
-
-        return url;
     }
 
     // Returns true if we handle successfully and resending the request

--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -1728,7 +1728,11 @@ private:
         DWORD urlSize{ 0 };
         if(FALSE == WinHttpQueryOption(hRequestHandle, WINHTTP_OPTION_URL, nullptr, &urlSize) || urlSize == 0)
         {
-            return U("");
+            // Ignore 'ERROR_INSUFFICIENT_BUFFER' because it is expected when passing a null 'lpBuffer' to query 'lpdwBufferLength'
+            if (ERROR_INSUFFICIENT_BUFFER != GetLastError())
+            {
+                return U("");
+            }
         }
 
         auto urlwchar = new WCHAR[urlSize / sizeof(WCHAR)];


### PR DESCRIPTION
If cpprestsdk is used in an environment where a web proxy requires authentication, and if an invalid username/password is provided, the request will be continuously retried.

For example:
```
http_client_config clientConfig;
web::web_proxy proxy;
web::credentials proxyCreds(U"username", U"invalidpassword");
proxy.set_credentials(proxyCreds);
clientConfig.set_proxy(proxy);
```

The initial HTTP request would result in a 407 "Proxy Authentication Required" response as expected. This would call `winhttp_client::handle_authentication_failure` which would replay the request with the provided proxy creds as expected. But since those creds are invalid, `winhttp_client::handle_authentication_failure` would continue replaying the request over and over.

This is due to the following code:
```
bool is_redirect = false;
try
{
    web::uri current_uri(get_request_url(hRequestHandle));
    is_redirect = p_request_context->m_request.absolute_uri().to_string() != current_uri.to_string();
}
catch (const std::exception&) {}

if (is_redirect || !p_request_context->m_proxy_authentication_tried)
{
    cred = p_request_context->m_http_client->client_config().proxy().credentials();
    p_request_context->m_proxy_authentication_tried = true;
}
```

The issue is with the call to `winhttp_client::get_request_url`. The bug is that this method *always* returns an empty string, resulting in `is_redirect` incorrectly always getting set to `true`. That will always trigger another attempt which will always fail.

The fix is to ensure `winhttp_client::get_request_url` returns a valid URL when one exists. That will result in the attempt retry logic only getting triggered one time, when `p_request_context->m_proxy_authentication_tried` is `false`.
