### PR TITLE
FIX: crash with std::logic_error when reusing a connection that timed out on the server

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -53,3 +53,4 @@ Christian Deneke (chris0x44)
 leetal
 
 Benjamin Lee (mobileben)
+René Meusel (reneme)

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1327,7 +1327,7 @@ private:
             // replay the just-failed request. Otherwise we assume that no data
             // was sent in the first place.
             const auto& instream = new_ctx->m_request._get_impl()->instream();
-            if (instream) {
+            if (instream && instream.can_seek()) {
                 try {
                     // As stated in the commit message of f4f2348, we might
                     // encounter streams that are not capable of rewinding. In

--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1327,16 +1327,21 @@ private:
             // replay the just-failed request. Otherwise we assume that no data
             // was sent in the first place.
             const auto& instream = new_ctx->m_request._get_impl()->instream();
-            if (instream && instream.can_seek()) {
-                try {
+            if (instream && instream.can_seek())
+            {
+                try
+                {
                     // As stated in the commit message of f4f2348, we might
                     // encounter streams that are not capable of rewinding. In
                     // case there is an exception we report it to the user and
                     // give up.
                     instream.seek(0);
-                } catch (const std::exception &ex) {
+                }
+                catch (const std::exception& ex)
+                {
                     report_error(std::string("failed to rewind input stream: ") + ex.what(),
-                                 ec, httpclient_errorcode_context::readheader);
+                                 ec,
+                                 httpclient_errorcode_context::readheader);
                 }
             }
 


### PR DESCRIPTION
This fixes a crash that was mentioned in several issues (#857, #979, ?) -- please see there for details. It builds on the hotfix in #979 and enhances it with error reporting in case of a failed send stream rewinding.

I'd appreciate some opinions on this patch: @vadz @fcharlie @BillyONeal 

Thanks!