### PR TITLE
Handle multi-byte unicode characters in json parsing

### DIFF
--- a/Release/src/json/json_parsing.cpp
+++ b/Release/src/json/json_parsing.cpp
@@ -729,7 +729,7 @@ inline bool JSON_Parser<CharType>::handle_unescape_char(Token& token)
             }
 
             // handle multi-block characters that start with a high-surrogate
-            if (decoded > H_SURROGATE_START && decoded < H_SURROGATE_END)
+            if (decoded >= H_SURROGATE_START && decoded <= H_SURROGATE_END)
             {
                 // skip escape character '\u'
                 if (NextCharacter() != '\\' || NextCharacter() != 'u')

--- a/Release/tests/functional/json/parsing_tests.cpp
+++ b/Release/tests/functional/json/parsing_tests.cpp
@@ -159,7 +159,7 @@ SUITE(parsing_tests)
             input.append(2, ch);
             json::value val = json::value::parse(input);
             VERIFY_IS_TRUE(val.is_object());
-        VERIFY_ARE_EQUAL(U("2"), val[U("1"]).serialize());
+            VERIFY_ARE_EQUAL(U("2"), val[U("1")].serialize());
         }
     }
 
@@ -212,6 +212,12 @@ SUITE(parsing_tests)
         // Euro sign as a hexidecmial UTF-8
         const auto euro = to_string_t("\xE2\x82\xAC");
         VERIFY_ARE_EQUAL(euro, str.as_string());
+
+        // UTF-16 character with surrogate pair
+        str = json::value::parse(U("\"\\ud83d\\ude00\""));
+        // Grinning Face emoji as a hexadecimal UTF-8
+        const auto emoji = to_string_t("\xF0\x9F\x98\x80");
+        VERIFY_ARE_EQUAL(emoji, str.as_string());
 
         VERIFY_PARSING_THROW(json::value::parse(U("\"\\u0klB\"")));
     }


### PR DESCRIPTION
Multi-byte characters (e.g. Emojis) in JSONs could not be parsed. Parsing failed with error `UTF-16 string is missing low surrogate`.
The code now checks if the first byte is a "High Surrogate" byte, which suggests, that there is a following byte.

Related to #139, #469, #635 (to some extend), 