### PR TITLE
http_compression.cpp: fix build with gcc 4.7

### DIFF
--- a/Release/src/http/common/http_compression.cpp
+++ b/Release/src/http/common/http_compression.cpp
@@ -600,6 +600,7 @@ private:
 class generic_compress_factory : public compress_factory
 {
 public:
+    ~generic_compress_factory() CPPREST_NOEXCEPT {}
     generic_compress_factory(const utility::string_t& algorithm,
                              std::function<std::unique_ptr<compress_provider>()> make_compressor)
         : m_algorithm(algorithm), _make_compressor(make_compressor)
@@ -619,6 +620,7 @@ private:
 class generic_decompress_factory : public decompress_factory
 {
 public:
+    ~generic_decompress_factory() CPPREST_NOEXCEPT {}
     generic_decompress_factory(const utility::string_t& algorithm,
                                uint16_t weight,
                                std::function<std::unique_ptr<decompress_provider>()> make_decompressor)


### PR DESCRIPTION
At GCC 4.7, C++11 rules for noexcept specification of implicit
destructors (and default specification on explicit destructors without
exception specifications) aren't perfectly implemented, see:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53613

Fixes:
 - http://autobuild.buildroot.org/results/a080dbe2977cd35e4f8351d864bd71aaa8f9b743

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>