### PR TITLE
Enable testing from root directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.1)
 project(cpprestsdk-root NONE)
-
+enable_testing()
 add_subdirectory(Release)


### PR DESCRIPTION
As per the [documentation](https://cmake.org/cmake/help/latest/command/enable_testing.html):

> Note that ctest expects to find a test file in the build directory root. Therefore, this command should be in the source directory root.

`enable_testing()` in the Release subdirectory has no effect when cmake is called with the root file causing a ``make: *** No rule to make target `test'`` error when running `make test`.