### PR TITLE
Gate stdext::checked_array_iterator usage on _ITERATOR_DEBUG_LEVEL

### DIFF
--- a/Release/include/cpprest/containerstream.h
+++ b/Release/include/cpprest/containerstream.h
@@ -399,7 +399,7 @@ private:
         auto readBegin = std::begin(m_data) + m_current_position;
         auto readEnd = std::begin(m_data) + newPos;
 
-#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
+#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
         // Avoid warning C4996: Use checked iterators under SECURE_SCL
         std::copy(readBegin, readEnd, stdext::checked_array_iterator<_CharType*>(ptr, count));
 #else

--- a/Release/include/cpprest/containerstream.h
+++ b/Release/include/cpprest/containerstream.h
@@ -399,7 +399,7 @@ private:
         auto readBegin = std::begin(m_data) + m_current_position;
         auto readEnd = std::begin(m_data) + newPos;
 
-#ifdef _WIN32
+#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
         // Avoid warning C4996: Use checked iterators under SECURE_SCL
         std::copy(readBegin, readEnd, stdext::checked_array_iterator<_CharType*>(ptr, count));
 #else

--- a/Release/include/cpprest/producerconsumerstream.h
+++ b/Release/include/cpprest/producerconsumerstream.h
@@ -438,7 +438,7 @@ private:
             _CharType* beg = rbegin();
             _CharType* end = rbegin() + countRead;
 
-#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
+#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
             // Avoid warning C4996: Use checked iterators under SECURE_SCL
             std::copy(beg, end, stdext::checked_array_iterator<_CharType*>(dest, count));
 #else
@@ -461,7 +461,7 @@ private:
 
             const _CharType* srcEnd = src + countWritten;
 
-#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
+#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
             // Avoid warning C4996: Use checked iterators under SECURE_SCL
             std::copy(src, srcEnd, stdext::checked_array_iterator<_CharType*>(wbegin(), static_cast<size_t>(avail)));
 #else

--- a/Release/include/cpprest/producerconsumerstream.h
+++ b/Release/include/cpprest/producerconsumerstream.h
@@ -438,7 +438,7 @@ private:
             _CharType* beg = rbegin();
             _CharType* end = rbegin() + countRead;
 
-#ifdef _WIN32
+#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
             // Avoid warning C4996: Use checked iterators under SECURE_SCL
             std::copy(beg, end, stdext::checked_array_iterator<_CharType*>(dest, count));
 #else
@@ -461,7 +461,7 @@ private:
 
             const _CharType* srcEnd = src + countWritten;
 
-#ifdef _WIN32
+#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
             // Avoid warning C4996: Use checked iterators under SECURE_SCL
             std::copy(src, srcEnd, stdext::checked_array_iterator<_CharType*>(wbegin(), static_cast<size_t>(avail)));
 #else

--- a/Release/include/cpprest/rawptrstream.h
+++ b/Release/include/cpprest/rawptrstream.h
@@ -439,7 +439,7 @@ private:
         auto readBegin = m_data + m_current_position;
         auto readEnd = m_data + newPos;
 
-#ifdef _WIN32
+#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
         // Avoid warning C4996: Use checked iterators under SECURE_SCL
         std::copy(readBegin, readEnd, stdext::checked_array_iterator<_CharType*>(ptr, count));
 #else
@@ -466,7 +466,7 @@ private:
         if (newSize > m_size) throw std::runtime_error("Writing past the end of the buffer");
 
             // Copy the data
-#ifdef _WIN32
+#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
         // Avoid warning C4996: Use checked iterators under SECURE_SCL
         std::copy(ptr, ptr + count, stdext::checked_array_iterator<_CharType*>(m_data, m_size, m_current_position));
 #else

--- a/Release/include/cpprest/rawptrstream.h
+++ b/Release/include/cpprest/rawptrstream.h
@@ -439,7 +439,7 @@ private:
         auto readBegin = m_data + m_current_position;
         auto readEnd = m_data + newPos;
 
-#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
+#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
         // Avoid warning C4996: Use checked iterators under SECURE_SCL
         std::copy(readBegin, readEnd, stdext::checked_array_iterator<_CharType*>(ptr, count));
 #else
@@ -466,7 +466,7 @@ private:
         if (newSize > m_size) throw std::runtime_error("Writing past the end of the buffer");
 
             // Copy the data
-#if defined(_WIN32) && (_ITERATOR_DEBUG_LEVEL != 0)
+#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
         // Avoid warning C4996: Use checked iterators under SECURE_SCL
         std::copy(ptr, ptr + count, stdext::checked_array_iterator<_CharType*>(m_data, m_size, m_current_position));
 #else


### PR DESCRIPTION
Fix for #1069 

[checked_array_iterator](https://docs.microsoft.com/en-us/cpp/standard-library/checked-array-iterator-class?view=vs-2017) is a Microsoft extension to the C++ Standard Library.  In order to build cpprestsdk using other libraries such as libc++, the extension needs to be gated with a Microsoft specific macro.  In this case [_ITERATOR_DEBUG_LEVEL](https://docs.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=vs-2017) is the preferred macro for using checked iterators (As _SECURE_SCL is marked deprecated) .

I've validated this builds using MSVC and clang.cl.exe/libc++.

Note: The CMake file sets _SCL_SECURE_NO_WARNINGS which disables the warning that the code in question is attempting to fix.

`elseif(WIN32)`
  `add_definitions(-DUNICODE -D_UNICODE -DWIN32 -D_SCL_SECURE_NO_WARNINGS)`