### PR TITLE
Rewrite date formatting and parsing

### DIFF
--- a/Release/include/cpprest/asyncrt_utils.h
+++ b/Release/include/cpprest/asyncrt_utils.h
@@ -630,15 +630,6 @@ private:
     static const interval_type _hourTicks = 60 * 60 * _secondTicks;
     static const interval_type _dayTicks = 24 * 60 * 60 * _secondTicks;
 
-#ifdef _WIN32
-    // void* to avoid pulling in windows.h
-    static _ASYNCRTIMP bool __cdecl system_type_to_datetime(/*SYSTEMTIME*/ void* psysTime,
-                                                            uint64_t seconds,
-                                                            datetime* pdt);
-#else
-    static datetime timeval_to_datetime(const timeval& time);
-#endif
-
     // Private constructor. Use static methods to create an instance.
     datetime(interval_type interval) : m_interval(interval) {}
 
@@ -699,7 +690,6 @@ public:
     void set_length(int length) { m_length = length; }
 
 private:
-    static const utility::string_t c_allowed_chars;
     std::mt19937 m_random;
     int m_length;
 };

--- a/Release/src/pch/stdafx.h
+++ b/Release/src/pch/stdafx.h
@@ -61,7 +61,6 @@
 #undef BOOST_NO_CXX11_NULLPTR
 #endif
 #include "boost/bind/bind.hpp"
-#include "boost/date_time/posix_time/posix_time_types.hpp"
 #include "boost/thread/condition_variable.hpp"
 #include "boost/thread/mutex.hpp"
 #include <fcntl.h>

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -17,6 +17,7 @@
 #include <cpprest/asyncrt_utils.h>
 #include <stdexcept>
 #include <string>
+#include <time.h>
 
 using namespace web;
 using namespace utility;

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -18,18 +18,6 @@
 #include <stdexcept>
 #include <string>
 
-#ifndef _WIN32
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/date_time/posix_time/posix_time_io.hpp>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-#endif
-
 using namespace web;
 using namespace utility;
 using namespace utility::conversions;

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -15,7 +15,6 @@
 
 #include <algorithm>
 #include <cpprest/asyncrt_utils.h>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -1372,38 +1371,32 @@ utility::seconds __cdecl timespan::xml_duration_to_seconds(const utility::string
     // The final S could be omitted
 
     int64_t numSecs = 0;
-
-    utility::istringstream_t is(timespanString);
-    is.imbue(std::locale::classic());
-    auto eof = std::char_traits<utility::char_t>::eof();
-
-    std::basic_istream<utility::char_t>::int_type c;
-    c = is.get(); // P
-
-    while (c != eof)
+    auto cursor = timespanString.c_str();
+    auto c = *cursor++; // skip 'P'
+    while (c)
     {
         int val = 0;
-        c = is.get();
+        c = *cursor++;
 
-        while (is_digit((utility::char_t)c))
+        while (ascii_isdigit(c))
         {
-            val = val * 10 + (c - L'0');
-            c = is.get();
+            val = val * 10 + (c - _XPLATSTR('0'));
+            c = *cursor++;
 
-            if (c == '.')
+            if (c == _XPLATSTR('.'))
             {
                 // decimal point is not handled
                 do
                 {
-                    c = is.get();
-                } while (is_digit((utility::char_t)c));
+                    c = *cursor++;
+                } while (ascii_isdigit(c));
             }
         }
 
-        if (c == L'D') numSecs += val * 24 * 3600; // days
-        if (c == L'H') numSecs += val * 3600;      // Hours
-        if (c == L'M') numSecs += val * 60;        // Minutes
-        if (c == L'S' || c == eof)
+        if (c == _XPLATSTR('D')) numSecs += val * 24 * 3600; // days
+        if (c == _XPLATSTR('H')) numSecs += val * 3600;      // Hours
+        if (c == _XPLATSTR('M')) numSecs += val * 60;        // Minutes
+        if (c == _XPLATSTR('S') || c == _XPLATSTR('\0'))
         {
             numSecs += val; // seconds
             break;

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -932,7 +932,7 @@ datetime __cdecl datetime::from_string(const utility::string_t& dateString, date
     datetime result;
     time_t seconds;
     uint64_t frac_sec = 0;
-    struct tm t = {0};
+    struct tm t{};
     auto str = dateString.c_str();
     if (format == RFC_1123)
     {

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -856,7 +856,7 @@ static time_t make_gm_time(struct tm* t)
         }
         setenv("TZ", "UTC", 1);
 
-        time = mktime(&output);
+        time = mktime(t);
 
         if (prev_env_cstr)
         {

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -677,7 +677,7 @@ static char* format_fractional_seconds(const int fractionalSeconds, char* const 
 #ifdef _MSC_VER
     size_t appended = sprintf_s(output, 9, ".%07d", fractionalSeconds);
 #else  // ^^^ _MSC_VER // !_MSC_VER vvv
-    size_t appended = sprintf(output, 9, ".%07d", fractionalSeconds);
+    size_t appended = sprintf(output,".%07d", fractionalSeconds);
 #endif // _MSC_VER
     while (output[appended - 1] == '0')
     {

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -695,12 +695,12 @@ utility::string_t datetime::to_string(date_format format) const
     struct tm t;
 #ifdef _MSC_VER
     if (gmtime_s(&t, &time) != 0)
-    {
-        throw std::invalid_argument("gmtime_s failed on the time supplied");
-    }
 #else // ^^^ _MSC_VER ^^^ // vvv !_MSC_VER vvv
-    const struct tm* t = gmtime(&time);
-#endif _MSC_VER
+    if (gmtime_r(&time, &t) == 0)
+#endif // _MSC_VER
+    {
+        throw std::invalid_argument("gmtime_r/s failed on the time supplied");
+    }
 
     char outBuffer[38]; // Thu, 01 Jan 1970 00:00:00.1234567 GMT\0
     char* outCursor = outBuffer;

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -629,8 +629,6 @@ std::string __cdecl conversions::to_utf8string(const utf16string& value) { retur
 
 utf16string __cdecl conversions::to_utf16string(const std::string& value) { return utf8_to_utf16(value); }
 
-static bool is_digit(utility::char_t c) { return c >= _XPLATSTR('0') && c <= _XPLATSTR('9'); }
-
 static const uint64_t ntToUnixOffsetSeconds = 11644473600U; // diff between windows and unix epochs (seconds)
 
 datetime __cdecl datetime::utc_now()

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -300,10 +300,6 @@ SUITE(datetime)
         for (const auto& str : bad_strings)
         {
             auto dt = utility::datetime::from_string(str, utility::datetime::RFC_1123);
-            if (dt.to_interval() != 0)
-            {
-                _putws(str.c_str());
-            }
             VERIFY_ARE_EQUAL(0, dt.to_interval());
         }
     }

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -74,16 +74,6 @@ SUITE(datetime)
         }
     }
 
-    TEST(parsing_time_extended)
-    {
-        // ISO 8601
-        {
-            auto dt = utility::datetime::from_string(_XPLATSTR("14:30:01Z"), utility::datetime::ISO_8601);
-
-            VERIFY_ARE_NOT_EQUAL(0u, dt.to_interval());
-        }
-    }
-
     void TestDateTimeRoundtrip(utility::string_t str, utility::string_t strExpected)
     {
         auto dt = utility::datetime::from_string(str, utility::datetime::ISO_8601);
@@ -101,6 +91,8 @@ SUITE(datetime)
 
     TEST(parsing_time_roundtrip_datetime2)
     {
+        // lose the last '000'
+        TestDateTimeRoundtrip(_XPLATSTR("2013-11-19T14:30:59.1234567000Z"), _XPLATSTR("2013-11-19T14:30:59.1234567Z"));
         // lose the last '999' without rounding up
         TestDateTimeRoundtrip(_XPLATSTR("2013-11-19T14:30:59.1234567999Z"), _XPLATSTR("2013-11-19T14:30:59.1234567Z"));
     }
@@ -129,16 +121,264 @@ SUITE(datetime)
         TestDateTimeRoundtrip(_XPLATSTR("2013-11-19T14:30:59.5Z"));
     }
 
-    TEST(parsing_time_roundtrip_datetime_invalid1,
-         "Ignore:Linux",
-         "Codeplex issue #115",
-         "Ignore:Apple",
-         "Codeplex issue #115")
+    void TestRfc1123IsTimeT(const utility::char_t* str, time_t t)
+    {
+        datetime dt = datetime::from_string(str, utility::datetime::RFC_1123);
+        uint64_t interval = dt.to_interval();
+        VERIFY_ARE_EQUAL(0, interval % 10000000);
+        interval /= 10000000;
+        interval -= 11644473600; // NT epoch adjustment
+        VERIFY_ARE_EQUAL(static_cast<uint64_t>(t), interval);
+    }
+
+    TEST(parsing_time_rfc1123_accepts_each_day)
+    {
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:00 GMT"), (time_t) 0);
+        TestRfc1123IsTimeT(_XPLATSTR("Fri, 02 Jan 1970 00:00:00 GMT"), (time_t) 86400 * 1);
+        TestRfc1123IsTimeT(_XPLATSTR("Sat, 03 Jan 1970 00:00:00 GMT"), (time_t) 86400 * 2);
+        TestRfc1123IsTimeT(_XPLATSTR("Sun, 04 Jan 1970 00:00:00 GMT"), (time_t) 86400 * 3);
+        TestRfc1123IsTimeT(_XPLATSTR("Mon, 05 Jan 1970 00:00:00 GMT"), (time_t) 86400 * 4);
+        TestRfc1123IsTimeT(_XPLATSTR("Tue, 06 Jan 1970 00:00:00 GMT"), (time_t) 86400 * 5);
+        TestRfc1123IsTimeT(_XPLATSTR("Wed, 07 Jan 1970 00:00:00 GMT"), (time_t) 86400 * 6);
+    }
+
+    TEST(parsing_time_rfc1123_boundary_cases)
+    {
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:00 GMT"), (time_t) 0);
+        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:14:06 GMT"), (time_t) INT_MAX - 1);
+#ifndef _USE_32BIT_TIME_T
+        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:13:07 -0001"), (time_t) INT_MAX);
+        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:14:07 -0000"), (time_t) INT_MAX);
+#endif // _USE_32BIT_TIME_T
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0000"), (time_t) 1547507781);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 -0001"), (time_t) 1547507841);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0001"), (time_t) 1547507721);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 -0100"), (time_t) 1547511381);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0100"), (time_t) 1547504181);
+    }
+
+    TEST(parsing_time_rfc1123_uses_each_field)
+    {
+        TestRfc1123IsTimeT(_XPLATSTR("02 Jan 1970 00:00:00 GMT"), (time_t) 86400);
+        TestRfc1123IsTimeT(_XPLATSTR("12 Jan 1970 00:00:00 GMT"), (time_t) 950400);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Feb 1970 00:00:00 GMT"), (time_t) 2678400);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 2000 00:00:00 GMT"), (time_t) 946684800);
+#ifndef _USE_32BIT_TIME_T
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 2100 00:00:00 GMT"), (time_t) 4102444800);
+#endif // _USE_32BIT_TIME_T
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1990 00:00:00 GMT"), (time_t) 631152000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1971 00:00:00 GMT"), (time_t) 31536000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 10:00:00 GMT"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 01:00:00 GMT"), (time_t) 3600);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:10:00 GMT"), (time_t) 600);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:01:00 GMT"), (time_t) 60);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:10 GMT"), (time_t) 10);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:01 GMT"), (time_t) 1);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 10:00:00 GMT"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 02:00:00 PST"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 03:00:00 PDT"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 03:00:00 MST"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 04:00:00 MDT"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 04:00:00 CST"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:00:00 CDT"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:00:00 EST"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 06:00:00 EDT"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 06:00:00 -0400"), (time_t) 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:59:00 -0401"), (time_t) 36000);
+    }
+
+    TEST(parsing_time_rfc1123_max_days)
+    {
+        TestRfc1123IsTimeT(_XPLATSTR("31 Jan 1970 00:00:00 GMT"), (time_t) 2592000);
+        TestRfc1123IsTimeT(_XPLATSTR("28 Feb 2019 00:00:00 GMT"), (time_t) 1551312000); // non leap year allows feb 28
+        TestRfc1123IsTimeT(_XPLATSTR("29 Feb 2020 00:00:00 GMT"), (time_t) 1582934400); // leap year allows feb 29
+        TestRfc1123IsTimeT(_XPLATSTR("31 Mar 1970 00:00:00 GMT"), (time_t) 7689600);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Apr 1970 00:00:00 GMT"), (time_t) 10281600);
+        TestRfc1123IsTimeT(_XPLATSTR("31 May 1970 00:00:00 GMT"), (time_t) 12960000);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Jun 1970 00:00:00 GMT"), (time_t) 15552000);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Jul 1970 00:00:00 GMT"), (time_t) 18230400);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Aug 1970 00:00:00 GMT"), (time_t) 20908800);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Sep 1970 00:00:00 GMT"), (time_t) 23500800);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Oct 1970 00:00:00 GMT"), (time_t) 26179200);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Nov 1970 00:00:00 GMT"), (time_t) 28771200);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Dec 1970 00:00:00 GMT"), (time_t) 31449600);
+    }
+
+    TEST(parsing_time_rfc1123_invalid_cases)
+    {
+        const utility::string_t bad_strings[] = {
+            _XPLATSTR("Ahu, 01 Jan 1970 00:00:00 GMT"), // bad letters in each place
+            _XPLATSTR("TAu, 01 Jan 1970 00:00:00 GMT"),
+            _XPLATSTR("ThA, 01 Jan 1970 00:00:00 GMT"),
+            _XPLATSTR("ThuA 01 Jan 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu,A01 Jan 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, A1 Jan 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 0A Jan 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01AJan 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Aan 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 JAn 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 JaA 1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 JanA1970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan A970 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1A70 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 19A0 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 197A 00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970A00:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 A0:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 0A:00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00A00:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:A0:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:0A:00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00A00 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:A0 GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:0A GMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00AGMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00 AMT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00 GAT"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00 GMA"),
+            _XPLATSTR(""), // truncation
+            _XPLATSTR("T"),
+            _XPLATSTR("Th"),
+            _XPLATSTR("Thu"),
+            _XPLATSTR("Thu,"),
+            _XPLATSTR("Thu, "),
+            _XPLATSTR("Thu, 0"),
+            _XPLATSTR("Thu, 01"),
+            _XPLATSTR("Thu, 01 "),
+            _XPLATSTR("Thu, 01 J"),
+            _XPLATSTR("Thu, 01 Ja"),
+            _XPLATSTR("Thu, 01 Jan"),
+            _XPLATSTR("Thu, 01 Jan "),
+            _XPLATSTR("Thu, 01 Jan 1"),
+            _XPLATSTR("Thu, 01 Jan 19"),
+            _XPLATSTR("Thu, 01 Jan 197"),
+            _XPLATSTR("Thu, 01 Jan 1970"),
+            _XPLATSTR("Thu, 01 Jan 1970 "),
+            _XPLATSTR("Thu, 01 Jan 1970 0"),
+            _XPLATSTR("Thu, 01 Jan 1970 00"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:0"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:0"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00 "),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00 G"),
+            _XPLATSTR("Thu, 01 Jan 1970 00:00:00 GM"),
+            _XPLATSTR("Fri, 01 Jan 1970 00:00:00 GMT"), // wrong day
+            _XPLATSTR("01 Jan 4970 00:00:00 GMT"), // year too big
+            _XPLATSTR("01 Jan 3001 00:00:00 GMT"),
+            _XPLATSTR("01 Xxx 1971 00:00:00 GMT"), // month bad
+            _XPLATSTR("00 Jan 1971 00:00:00 GMT"), // day too small
+            _XPLATSTR("32 Jan 1971 00:00:00 GMT"), // day too big
+            _XPLATSTR("30 Feb 1971 00:00:00 GMT"), // day too big for feb
+            _XPLATSTR("30 Feb 1971 00:00:00 GMT"), // day too big for feb (non-leap year)
+            _XPLATSTR("32 Mar 1971 00:00:00 GMT"), // other months
+            _XPLATSTR("31 Apr 1971 00:00:00 GMT"),
+            _XPLATSTR("32 May 1971 00:00:00 GMT"),
+            _XPLATSTR("31 Jun 1971 00:00:00 GMT"),
+            _XPLATSTR("32 Jul 1971 00:00:00 GMT"),
+            _XPLATSTR("32 Aug 1971 00:00:00 GMT"),
+            _XPLATSTR("31 Sep 1971 00:00:00 GMT"),
+            _XPLATSTR("32 Oct 1971 00:00:00 GMT"),
+            _XPLATSTR("31 Nov 1971 00:00:00 GMT"),
+            _XPLATSTR("32 Dec 1971 00:00:00 GMT"),
+            _XPLATSTR("01 Jan 1971 70:00:00 GMT"), // hour too big
+            _XPLATSTR("01 Jan 1971 24:00:00 GMT"),
+            _XPLATSTR("01 Jan 1971 00:60:00 GMT"), // minute too big
+            _XPLATSTR("01 Jan 1971 00:00:70 GMT"), // second too big
+            _XPLATSTR("01 Jan 1971 00:00:61 GMT"),
+            _XPLATSTR("01 Jan 1969 00:00:00 GMT"), // underflow
+            _XPLATSTR("01 Jan 1969 00:00:00 CEST"), // bad tz
+            _XPLATSTR("01 Jan 1970 00:00:00 +2400"), // bad tzoffsets
+            _XPLATSTR("01 Jan 1970 00:00:00 -3000"),
+            _XPLATSTR("01 Jan 1970 00:00:00 +2160"),
+            _XPLATSTR("01 Jan 1970 00:00:00 -2400"),
+            _XPLATSTR("01 Jan 1970 00:00:00 -2160"),
+        };
+
+        for (const auto& str : bad_strings)
+        {
+            auto dt = utility::datetime::from_string(str, utility::datetime::RFC_1123);
+            if (dt.to_interval() != 0)
+            {
+                _putws(str.c_str());
+            }
+            VERIFY_ARE_EQUAL(0, dt.to_interval());
+        }
+    }
+
+    TEST(parsing_time_iso8601_boundary_cases)
+    {
+        // boundary cases:
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:00:00Z"));                                         // epoch
+        TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:14:06+00:00"), _XPLATSTR("2038-01-19T03:14:06Z")); // INT_MAX - 1
+#ifndef _USE_32BIT_TIME_T
+        TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:13:07-00:01"),
+                              _XPLATSTR("2038-01-19T03:14:07Z")); // INT_MAX after subtacting 1
+        TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:14:07-00:00"), _XPLATSTR("2038-01-19T03:14:07Z"));
+#endif // _USE_32BIT_TIME_T
+    }
+
+    TEST(parsing_time_iso8601_uses_each_timezone_digit)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("2019-01-14T23:16:21+00:00"), _XPLATSTR("2019-01-14T23:16:21Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("2019-01-14T23:16:21-00:01"), _XPLATSTR("2019-01-14T23:17:21Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("2019-01-14T23:16:21+00:01"), _XPLATSTR("2019-01-14T23:15:21Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("2019-01-14T23:16:21-01:00"), _XPLATSTR("2019-01-15T00:16:21Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("2019-01-14T23:16:21+01:00"), _XPLATSTR("2019-01-14T22:16:21Z"));
+    }
+
+    TEST(parsing_time_iso8601_uses_each_digit)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:00:01Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:01:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T01:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-02T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-02-01T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1971-01-01T00:00:00Z"));
+
+        TestDateTimeRoundtrip(_XPLATSTR("1999-01-01T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-12-01T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-09-01T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-30T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-31T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T23:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T19:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:59:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:00:59Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:00:60Z"), _XPLATSTR("1970-01-01T00:01:00Z")); // leap seconds
+    }
+
+    TEST(parsing_time_iso8601_accepts_month_max_days)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-31T00:00:00Z")); // jan
+        TestDateTimeRoundtrip(_XPLATSTR("2019-02-28T00:00:00Z")); // non leap year allows feb 28
+        TestDateTimeRoundtrip(_XPLATSTR("2020-02-29T00:00:00Z")); // leap year allows feb 29
+        TestDateTimeRoundtrip(_XPLATSTR("1970-03-31T00:00:00Z")); // mar
+        TestDateTimeRoundtrip(_XPLATSTR("1970-04-30T00:00:00Z")); // apr
+        TestDateTimeRoundtrip(_XPLATSTR("1970-05-31T00:00:00Z")); // may
+        TestDateTimeRoundtrip(_XPLATSTR("1970-06-30T00:00:00Z")); // jun
+        TestDateTimeRoundtrip(_XPLATSTR("1970-07-31T00:00:00Z")); // jul
+        TestDateTimeRoundtrip(_XPLATSTR("1970-08-31T00:00:00Z")); // aug
+        TestDateTimeRoundtrip(_XPLATSTR("1970-09-30T00:00:00Z")); // sep
+        TestDateTimeRoundtrip(_XPLATSTR("1970-10-31T00:00:00Z")); // oct
+        TestDateTimeRoundtrip(_XPLATSTR("1970-11-30T00:00:00Z")); // nov
+        TestDateTimeRoundtrip(_XPLATSTR("1970-12-31T00:00:00Z")); // dec
+    }
+
+    TEST(parsing_time_iso8601_accepts_lowercase_t_z)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01t00:00:00Z"), _XPLATSTR("1970-01-01T00:00:00Z"));
+        TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:00:00z"), _XPLATSTR("1970-01-01T00:00:00Z"));
+    }
+
+    TEST(parsing_time_roundtrip_datetime_accepts_invalid_no_trailing_timezone)
     {
         // No digits after the dot, or non-digits. This is not a valid input, but we should not choke on it,
         // Simply ignore the bad fraction
         const utility::string_t bad_strings[] = {_XPLATSTR("2013-11-19T14:30:59.Z"),
-                                                 _XPLATSTR("2013-11-19T14:30:59.1a2Z")};
+                                                 _XPLATSTR("2013-11-19T14:30:59.a12Z")};
         utility::string_t str_corrected = _XPLATSTR("2013-11-19T14:30:59Z");
 
         for (const auto& str : bad_strings)
@@ -151,12 +391,87 @@ SUITE(datetime)
 
     TEST(parsing_time_roundtrip_datetime_invalid2)
     {
-        // Variouls unsupported cases. In all cases, we have produce an empty date time
+        // Various unsupported cases. In all cases, we have produce an empty date time
         const utility::string_t bad_strings[] = {
-            _XPLATSTR(""),     // empty
-            _XPLATSTR(".Z"),   // too short
-            _XPLATSTR(".Zx"),  // no trailing Z
-            _XPLATSTR("3.14Z") // not a valid date
+            _XPLATSTR(""),                     // empty
+            _XPLATSTR(".Z"),                   // too short
+            _XPLATSTR(".Zx"),                  // no trailing Z
+            _XPLATSTR("3.14Z")                 // not a valid date
+            _XPLATSTR("a971-01-01T00:00:00Z"), // any non digits or valid separators
+            _XPLATSTR("1a71-01-01T00:00:00Z"),
+            _XPLATSTR("19a1-01-01T00:00:00Z"),
+            _XPLATSTR("197a-01-01T00:00:00Z"),
+            _XPLATSTR("1971a01-01T00:00:00Z"),
+            _XPLATSTR("1971-a1-01T00:00:00Z"),
+            _XPLATSTR("1971-0a-01T00:00:00Z"),
+            _XPLATSTR("1971-01a01T00:00:00Z"),
+            _XPLATSTR("1971-01-a1T00:00:00Z"),
+            _XPLATSTR("1971-01-0aT00:00:00Z"),
+            // _XPLATSTR("1971-01-01a00:00:00Z"), parsed as complete date
+            _XPLATSTR("1971-01-01Ta0:00:00Z"),
+            _XPLATSTR("1971-01-01T0a:00:00Z"),
+            _XPLATSTR("1971-01-01T00a00:00Z"),
+            _XPLATSTR("1971-01-01T00:a0:00Z"),
+            _XPLATSTR("1971-01-01T00:0a:00Z"),
+            _XPLATSTR("1971-01-01T00:00a00Z"),
+            _XPLATSTR("1971-01-01T00:00:a0Z"),
+            _XPLATSTR("1971-01-01T00:00:0aZ"),
+            // "1971-01-01T00:00:00a", accepted as per invalid_no_trailing_timezone above
+            _XPLATSTR("1"), // truncation
+            _XPLATSTR("19"),
+            _XPLATSTR("197"),
+            _XPLATSTR("1970"),
+            _XPLATSTR("1970-"),
+            _XPLATSTR("1970-0"),
+            _XPLATSTR("1970-01"),
+            _XPLATSTR("1970-01-"),
+            _XPLATSTR("1970-01-0"),
+            // _XPLATSTR("1970-01-01"), complete date
+            _XPLATSTR("1970-01-01T"),
+            _XPLATSTR("1970-01-01T0"),
+            _XPLATSTR("1970-01-01T00"),
+            _XPLATSTR("1970-01-01T00:"),
+            _XPLATSTR("1970-01-01T00:0"),
+            _XPLATSTR("1970-01-01T00:00"),
+            _XPLATSTR("1970-01-01T00:00:"),
+            _XPLATSTR("1970-01-01T00:00:0"),
+            // _XPLATSTR("1970-01-01T00:00:00"), // accepted as invalid timezone above
+            _XPLATSTR("4970-01-01T00:00:00Z"), // year too big
+            _XPLATSTR("3001-01-01T00:00:00Z"),
+            _XPLATSTR("1971-00-01T00:00:00Z"), // month too small
+            _XPLATSTR("1971-20-01T00:00:00Z"), // month too big
+            _XPLATSTR("1971-13-01T00:00:00Z"),
+            _XPLATSTR("1971-01-00T00:00:00Z"), // day too small
+            _XPLATSTR("1971-01-32T00:00:00Z"), // day too big
+            _XPLATSTR("1971-02-30T00:00:00Z"), // day too big for feb
+            _XPLATSTR("1971-02-30T00:00:00Z"), // day too big for feb (non-leap year)
+            _XPLATSTR("1971-03-32T00:00:00Z"), // other months
+            _XPLATSTR("1971-04-31T00:00:00Z"),
+            _XPLATSTR("1971-05-32T00:00:00Z"),
+            _XPLATSTR("1971-06-31T00:00:00Z"),
+            _XPLATSTR("1971-07-32T00:00:00Z"),
+            _XPLATSTR("1971-08-32T00:00:00Z"),
+            _XPLATSTR("1971-09-31T00:00:00Z"),
+            _XPLATSTR("1971-10-32T00:00:00Z"),
+            _XPLATSTR("1971-11-31T00:00:00Z"),
+            _XPLATSTR("1971-12-32T00:00:00Z"),
+            _XPLATSTR("1971-01-01T70:00:00Z"), // hour too big
+            _XPLATSTR("1971-01-01T24:00:00Z"),
+            _XPLATSTR("1971-01-01T00:60:00Z"), // minute too big
+            _XPLATSTR("1971-01-01T00:00:70Z"), // second too big
+            _XPLATSTR("1971-01-01T00:00:61Z"),
+            _XPLATSTR("1969-01-01T00:00:00Z"), // underflow
+#ifdef _USE_32BIT_TIME_T
+            _XPLATSTR("3000-01-01T00:00:01Z"), // overflow
+#endif
+            _XPLATSTR("3001-01-01T00:00:00Z"),
+            _XPLATSTR("1970-01-01T00:00:00+00:01"), // time zone underflow
+            // _XPLATSTR("1970-01-01T00:00:00.Z"), // accepted as invalid timezone above
+            _XPLATSTR("1970-01-01T00:00:00+24:00"), // bad tzoffsets
+            _XPLATSTR("1970-01-01T00:00:00-30:00"),
+            _XPLATSTR("1970-01-01T00:00:00+21:60"),
+            _XPLATSTR("1970-01-01T00:00:00-24:00"),
+            _XPLATSTR("1970-01-01T00:00:00-21:60"),
         };
 
         for (const auto& str : bad_strings)
@@ -164,16 +479,6 @@ SUITE(datetime)
             auto dt = utility::datetime::from_string(str, utility::datetime::ISO_8601);
             VERIFY_ARE_EQUAL(dt.to_interval(), 0);
         }
-    }
-
-    TEST(parsing_time_roundtrip_time)
-    {
-        // time only without date
-        utility::string_t str = _XPLATSTR("14:30:59.1234567Z");
-        auto dt = utility::datetime::from_string(str, utility::datetime::ISO_8601);
-        utility::string_t str2 = dt.to_string(utility::datetime::ISO_8601);
-        // Must look for a substring now, since the date part is filled with today's date
-        VERIFY_IS_TRUE(str2.find(str) != std::string::npos);
     }
 
 } // SUITE(datetime)


### PR DESCRIPTION
This overhauls the RFC 1123 and ISO 8601 parsing with bits copied from the autorest C prototype, giving more consistent behavior across platforms, and removing unintended locale dependencies. (For example, before on POSIX on a German machine we might emit Die, 19 Mär 2019 09:59:57 which would be rejected by servers)

There is a subtle breaking change in that we previously accepted a time with no date, e.g. "12:12:12Z", and this change rejects that. However, such input is not a valid ISO 8601 input, and we were crazy about how we handled it before. Before, on Windows we would fill in the date with whatever the *current* date is, but on POSIX we would fill in January 1, 1970. Considering this was never consistent, and considering 99.999% of internet customers are going to be using RFC 3339 which requires all the components, I've dropped that special case.

Lots of tests also added.