### PR TITLE
Fix thread not joined

### DIFF
--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -400,25 +400,26 @@ public:
 
         m_state = CONNECTING;
         client.connect(con);
-        std::unique_lock<std::mutex> lock(m_wspp_client_lock);
-        m_thread = std::thread([&client]() {
+        {
+            std::lock_guard<std::mutex> lock(m_wspp_client_lock);
+            m_thread = std::thread([&client]() {
 #if defined(__ANDROID__)
-            crossplat::get_jvm_env();
+                crossplat::get_jvm_env();
 #endif
-            client.run();
+                client.run();
 #if defined(__ANDROID__)
-            crossplat::JVM.load()->DetachCurrentThread();
+                crossplat::JVM.load()->DetachCurrentThread();
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-            // OpenSSL stores some per thread state that never will be cleaned up until
-            // the dll is unloaded. If static linking, like we do, the state isn't cleaned up
-            // at all and will be reported as leaks.
-            // See http://www.openssl.org/support/faq.html#PROG13
-            ERR_remove_thread_state(nullptr);
+                // OpenSSL stores some per thread state that never will be cleaned up until
+                // the dll is unloaded. If static linking, like we do, the state isn't cleaned up
+                // at all and will be reported as leaks.
+                // See http://www.openssl.org/support/faq.html#PROG13
+                ERR_remove_thread_state(nullptr);
 #endif
-        });
-        lock.unlock();
+            });
+        } // unlock
         return pplx::create_task(m_connect_tce);
     }
 
@@ -656,7 +657,7 @@ private:
                 {
                     m_thread.join();
                 }
-            }
+            } // unlock
 
             // Delete client to make sure Websocketpp cleans up all Boost.Asio portions.
             m_client.reset();


### PR DESCRIPTION
I run into a **std::terminate issue** on Linux and I found there's a race condition between the creation of the thread that starts ASIO io_service, and the actual assignation of the thread object to `m_thread`. The new thread can try to connect and call *fail_handler* before the thread object is assigned. In this scenario, *fail_handler* will not join `m_thread` as it is still not joinable.

I modified the template method `connect_impl` in _src/websockets/client/ws_client_wspp.cpp_ to add some delay and reproduce the issue instead of using `gdb` but notice you can find easier to do it with said debugger. These are the modifications:

```c++
        auto tmpThread = std::thread([&client]() {
#if defined(__ANDROID__)
            crossplat::get_jvm_env();
#endif
            client.run();
#if defined(__ANDROID__)
            crossplat::JVM.load()->DetachCurrentThread();
#endif

#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
            // OpenSSL stores some per thread state that never will be cleaned up until
            // the dll is unloaded. If static linking, like we do, the state isn't cleaned up
            // at all and will be reported as leaks.
            // See http://www.openssl.org/support/faq.html#PROG13
            ERR_remove_thread_state(nullptr);
#endif
        });
        // my delay HERE
        std::this_thread::sleep_for(std::chrono::seconds(1));
        m_thread = std::move(tmpThread);
```

And with the following snippet I could reproduce the not joined thread:

```c++
#include <iostream>
#include <thread>
#include <pplx/pplxtasks.h>
#include <cpprest/ws_client.h>

// this is to avoid a data race in the scheduler creation reported by Google's thread sanitizer
auto scheduler = pplx::get_ambient_scheduler();

void handleTerminate() {
  std::cerr << "Unhandled exception or thread not joined\n";
  quick_exit(EXIT_FAILURE);
}

int main() {
  std::set_terminate(handleTerminate);
  auto ws = web::websockets::client::websocket_callback_client();
  try {
    ws.connect("ws://an_invalid_host").wait();
  } catch (const std::exception& ex) {
    std::cerr << "Ws connection error: " << ex.what() << std::endl;
  }
  return 0;
}
```

--------------

To test the changes in this PR, you can use the custom lib code (with the delay) but with the corresponding locks. If you run the snippet again, you will see the problem is gone.

If you want a more realistic scenario, I reproduced the problem in an application which creates lots of `websocket_callback_client`s at the same time and all of them fail at connecting to the endpoint.

--------------

This PR might fix #32 and #701