### PR TITLE
Workaround data-race on websocketpp's _htonll function

### DIFF
--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -62,7 +62,8 @@
 #pragma warning(disable : 4503)
 #endif
 
-// workaround data-race on websocketpp's _htonll function
+// Workaround data-race on websocketpp's _htonll function, see
+// https://github.com/Microsoft/cpprestsdk/pull/1082
 auto avoidDataRaceOnHtonll = websocketpp::lib::net::_htonll(0);
 
 // This is a hack to avoid memory leak reports from the debug MSVC CRT for all

--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -62,6 +62,9 @@
 #pragma warning(disable : 4503)
 #endif
 
+// workaround data-race on websocketpp's _htonll function
+auto avoidDataRaceOnHtonll = websocketpp::lib::net::_htonll(0);
+
 // This is a hack to avoid memory leak reports from the debug MSVC CRT for all
 // programs using the library: ASIO calls SSL_library_init() which calls
 // SSL_COMP_get_compression_methods(), which allocates some heap memory and the


### PR DESCRIPTION
This is the current implementation of [`_htonll` on websocketpp](https://github.com/zaphoyd/websocketpp/blob/master/websocketpp/common/network.hpp#L66-L85):

```c++
inline uint64_t _htonll(uint64_t src) {
    static int typ = TYP_INIT;
    unsigned char c;
    union {
        uint64_t ull;
        unsigned char c[8];
    } x;
    if (typ == TYP_INIT) {
        x.ull = 0x01;
        typ = (x.c[7] == 0x01ULL) ? TYP_BIGE : TYP_SMLE;
    }
    if (typ == TYP_BIGE)
        return src;
    x.ull = src;
    c = x.c[0]; x.c[0] = x.c[7]; x.c[7] = c;
    c = x.c[1]; x.c[1] = x.c[6]; x.c[6] = c;
    c = x.c[2]; x.c[2] = x.c[5]; x.c[5] = c;
    c = x.c[3]; x.c[3] = x.c[4]; x.c[4] = c;
    return x.ull;
}
```

As you can see, there is a data-race on the following block if multiple threads call the function at the same time **for the first time** (on subsequent calls the block won't be executed):

```c++
    if (typ == TYP_INIT) {
        x.ull = 0x01;
        typ = (x.c[7] == 0x01ULL) ? TYP_BIGE : TYP_SMLE;
    }
```

Until a fix is applied to [websocketpp](https://github.com/zaphoyd/websocketpp), this PR circumvent the issue forcing a first call to the function initializing a global variable.