### PR TITLE
Avoid resetting unique_ptr not being the owner of the pointed element

### DIFF
--- a/Release/src/websockets/client/ws_client_wspp.cpp
+++ b/Release/src/websockets/client/ws_client_wspp.cpp
@@ -653,9 +653,6 @@ private:
                 m_thread.join();
             }
 
-            // Delete client to make sure Websocketpp cleans up all Boost.Asio portions.
-            m_client.reset();
-
             if (connecting)
             {
                 websocket_exception exc(ec, build_error_msg(ec, "set_fail_handler"));


### PR DESCRIPTION
This PR is to avoid resetting a unique_ptr in a new thread as it (the new thread) is not the owner of the pointed element, and `unique_ptr` is not thread safe, so some obscure errors could happen. Consider this snippet for testing purposes:

```c++
#include <memory>
#include <thread>

int main() {
  std::unique_ptr<int> unique(new int);
  std::thread thread([&unique] () {
    unique.reset();
  });
  unique.reset();
  thread.join();
  return 0;
}
```

Both `unique.reset();` might be called at the same time causing UB. I think something similar is happening in [`shutdown_wspp_impl`](https://github.com/Microsoft/cpprestsdk/blob/master/Release/src/websockets/client/ws_client_wspp.cpp#L634).

What is the price of stop calling `m_client.reset();` as suggested in this PR?

This might be related to issue #32 