### PR TITLE
Allow error handling for time out in http_client_asio handle_connect

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1010,7 +1010,7 @@ private:
         else if (ec.value() == boost::system::errc::operation_canceled ||
                  ec.value() == boost::asio::error::operation_aborted)
         {
-            request_context::report_error(ec.value(), "Request canceled by user.");
+            report_error("Request canceled by user.", ec, httpclient_errorcode_context::connect);
         }
         else if (endpoints == tcp::resolver::iterator())
         {


### PR DESCRIPTION
This fixes #1052 by using the **asio_context** class's **report_error** function if there is an **operation_aborted** error code in the **handle_connect** function. This allows for it to check if it was aborted due to the timer timing out, and thus can throw the appropriate exception.

Previously, the **connections_and_errors:request_timeout_microsecond** would be flaky when the CPU was under load, or on slower CPUs, since the timeout_timer could close the **asio_context**'s connection before the **handle_connect** function was called. Since the error was being reported directly through the **request_context**, it was not checking if it was due to the timeout and was instead throwing a generic exception.