### PR TITLE
Parse and emit years from 1900 to 9999, and remove environment variable dependence on Android

### DIFF
--- a/Release/tests/functional/http/listener/request_handler_tests.cpp
+++ b/Release/tests/functional/http/listener/request_handler_tests.cpp
@@ -445,8 +445,6 @@ SUITE(request_handler_tests)
             headers[U("Request")] = U("Upload");
             headers[U("ImgNr")] = U("1");
 
-            char* pdata = new char[nbytes];
-
             // this help recognizing the leaked memory in the CRT/VLD dump
             std::string data;
             for (int j = 0; j < nbytes; j++)

--- a/Release/tests/functional/http/listener/request_handler_tests.cpp
+++ b/Release/tests/functional/http/listener/request_handler_tests.cpp
@@ -445,14 +445,12 @@ SUITE(request_handler_tests)
             headers[U("Request")] = U("Upload");
             headers[U("ImgNr")] = U("1");
 
-            utility::char_t* pdata = new utility::char_t[nbytes];
+            char* pdata = new char[nbytes];
 
             // this help recognizing the leaked memory in the CRT/VLD dump
+            std::string data;
             for (int j = 0; j < nbytes; j++)
-                pdata[j] = U('a') + (j % 26);
-            std::string data(pdata, pdata + nbytes);
-            delete[] pdata;
-
+                data.push_back('a' + (j % 26));
             VERIFY_ARE_EQUAL(0, p_client->request(methods::PUT, U("/path1"), headers, data));
             p_client->next_response()
                 .then([](test_response* p_response) {

--- a/Release/tests/functional/http/utilities/test_http_server.cpp
+++ b/Release/tests/functional/http/utilities/test_http_server.cpp
@@ -404,6 +404,7 @@ public:
         HTTP_RESPONSE response;
         ZeroMemory(&response, sizeof(HTTP_RESPONSE));
         response.StatusCode = status_code;
+#pragma warning(suppress: 4244) // intentionally narrow wchar_t -> char
         std::string reason(reason_phrase.begin(), reason_phrase.end());
         response.pReason = reason.c_str();
         response.ReasonLength = (USHORT)reason.length();

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -121,6 +121,16 @@ SUITE(datetime)
         TestDateTimeRoundtrip(_XPLATSTR("2013-11-19T14:30:59.5Z"));
     }
 
+    TEST(parsing_time_roundtrip_year_1900)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("1900-01-01T00:00:00Z"));
+    }
+
+    TEST(parsing_time_roundtrip_year_9999)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("9999-12-31T23:59:59Z"));
+    }
+
     void TestRfc1123IsTimeT(const utility::char_t* str, time_t t)
     {
         datetime dt = datetime::from_string(str, utility::datetime::RFC_1123);

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -131,7 +131,7 @@ SUITE(datetime)
         TestDateTimeRoundtrip(_XPLATSTR("9999-12-31T23:59:59Z"));
     }
 
-    void TestRfc1123IsTimeT(const utility::char_t* str, time_t t)
+    void TestRfc1123IsTimeT(const utility::char_t* str, uint64_t t)
     {
         datetime dt = datetime::from_string(str, utility::datetime::RFC_1123);
         uint64_t interval = dt.to_interval();
@@ -143,77 +143,71 @@ SUITE(datetime)
 
     TEST(parsing_time_rfc1123_accepts_each_day)
     {
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:00 GMT"), (time_t)0);
-        TestRfc1123IsTimeT(_XPLATSTR("Fri, 02 Jan 1970 00:00:00 GMT"), (time_t)86400 * 1);
-        TestRfc1123IsTimeT(_XPLATSTR("Sat, 03 Jan 1970 00:00:00 GMT"), (time_t)86400 * 2);
-        TestRfc1123IsTimeT(_XPLATSTR("Sun, 04 Jan 1970 00:00:00 GMT"), (time_t)86400 * 3);
-        TestRfc1123IsTimeT(_XPLATSTR("Mon, 05 Jan 1970 00:00:00 GMT"), (time_t)86400 * 4);
-        TestRfc1123IsTimeT(_XPLATSTR("Tue, 06 Jan 1970 00:00:00 GMT"), (time_t)86400 * 5);
-        TestRfc1123IsTimeT(_XPLATSTR("Wed, 07 Jan 1970 00:00:00 GMT"), (time_t)86400 * 6);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:00 GMT"), 0);
+        TestRfc1123IsTimeT(_XPLATSTR("Fri, 02 Jan 1970 00:00:00 GMT"), 86400 * 1);
+        TestRfc1123IsTimeT(_XPLATSTR("Sat, 03 Jan 1970 00:00:00 GMT"), 86400 * 2);
+        TestRfc1123IsTimeT(_XPLATSTR("Sun, 04 Jan 1970 00:00:00 GMT"), 86400 * 3);
+        TestRfc1123IsTimeT(_XPLATSTR("Mon, 05 Jan 1970 00:00:00 GMT"), 86400 * 4);
+        TestRfc1123IsTimeT(_XPLATSTR("Tue, 06 Jan 1970 00:00:00 GMT"), 86400 * 5);
+        TestRfc1123IsTimeT(_XPLATSTR("Wed, 07 Jan 1970 00:00:00 GMT"), 86400 * 6);
     }
 
     TEST(parsing_time_rfc1123_boundary_cases)
     {
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:00 GMT"), (time_t)0);
-        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:14:06 GMT"), (time_t)INT_MAX - 1);
-        if (sizeof(time_t) == 8)
-        {
-            TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:13:07 -0001"), (time_t)INT_MAX);
-            TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:14:07 -0000"), (time_t)INT_MAX);
-        }
-        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0000"), (time_t)1547507781);
-        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 -0001"), (time_t)1547507841);
-        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0001"), (time_t)1547507721);
-        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 -0100"), (time_t)1547511381);
-        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0100"), (time_t)1547504181);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:00 GMT"), 0);
+        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:14:06 GMT"), INT_MAX - 1);
+        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:13:07 -0001"), INT_MAX);
+        TestRfc1123IsTimeT(_XPLATSTR("19 Jan 2038 03:14:07 -0000"), INT_MAX);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0000"), 1547507781);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 -0001"), 1547507841);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0001"), 1547507721);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 -0100"), 1547511381);
+        TestRfc1123IsTimeT(_XPLATSTR("14 Jan 2019 23:16:21 +0100"), 1547504181);
     }
 
     TEST(parsing_time_rfc1123_uses_each_field)
     {
-        TestRfc1123IsTimeT(_XPLATSTR("02 Jan 1970 00:00:00 GMT"), (time_t)86400);
-        TestRfc1123IsTimeT(_XPLATSTR("12 Jan 1970 00:00:00 GMT"), (time_t)950400);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Feb 1970 00:00:00 GMT"), (time_t)2678400);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 2000 00:00:00 GMT"), (time_t)946684800);
-        if (sizeof(time_t) == 8)
-        {
-            TestRfc1123IsTimeT(_XPLATSTR("01 Jan 2100 00:00:00 GMT"), (time_t)4102444800);
-        }
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1990 00:00:00 GMT"), (time_t)631152000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1971 00:00:00 GMT"), (time_t)31536000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 10:00:00 GMT"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 01:00:00 GMT"), (time_t)3600);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:10:00 GMT"), (time_t)600);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:01:00 GMT"), (time_t)60);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:10 GMT"), (time_t)10);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:01 GMT"), (time_t)1);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 10:00:00 GMT"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 02:00:00 PST"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 03:00:00 PDT"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 03:00:00 MST"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 04:00:00 MDT"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 04:00:00 CST"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:00:00 CDT"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:00:00 EST"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 06:00:00 EDT"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 06:00:00 -0400"), (time_t)36000);
-        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:59:00 -0401"), (time_t)36000);
+        TestRfc1123IsTimeT(_XPLATSTR("02 Jan 1970 00:00:00 GMT"), 86400);
+        TestRfc1123IsTimeT(_XPLATSTR("12 Jan 1970 00:00:00 GMT"), 950400);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Feb 1970 00:00:00 GMT"), 2678400);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 2000 00:00:00 GMT"), 946684800);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 2100 00:00:00 GMT"), 4102444800);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1990 00:00:00 GMT"), 631152000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1971 00:00:00 GMT"), 31536000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 10:00:00 GMT"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 01:00:00 GMT"), 3600);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:10:00 GMT"), 600);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:01:00 GMT"), 60);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:10 GMT"), 10);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 00:00:01 GMT"), 1);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 10:00:00 GMT"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 02:00:00 PST"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 03:00:00 PDT"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 03:00:00 MST"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 04:00:00 MDT"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 04:00:00 CST"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:00:00 CDT"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:00:00 EST"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 06:00:00 EDT"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 06:00:00 -0400"), 36000);
+        TestRfc1123IsTimeT(_XPLATSTR("01 Jan 1970 05:59:00 -0401"), 36000);
     }
 
     TEST(parsing_time_rfc1123_max_days)
     {
-        TestRfc1123IsTimeT(_XPLATSTR("31 Jan 1970 00:00:00 GMT"), (time_t)2592000);
-        TestRfc1123IsTimeT(_XPLATSTR("28 Feb 2019 00:00:00 GMT"), (time_t)1551312000); // non leap year allows feb 28
-        TestRfc1123IsTimeT(_XPLATSTR("29 Feb 2020 00:00:00 GMT"), (time_t)1582934400); // leap year allows feb 29
-        TestRfc1123IsTimeT(_XPLATSTR("31 Mar 1970 00:00:00 GMT"), (time_t)7689600);
-        TestRfc1123IsTimeT(_XPLATSTR("30 Apr 1970 00:00:00 GMT"), (time_t)10281600);
-        TestRfc1123IsTimeT(_XPLATSTR("31 May 1970 00:00:00 GMT"), (time_t)12960000);
-        TestRfc1123IsTimeT(_XPLATSTR("30 Jun 1970 00:00:00 GMT"), (time_t)15552000);
-        TestRfc1123IsTimeT(_XPLATSTR("31 Jul 1970 00:00:00 GMT"), (time_t)18230400);
-        TestRfc1123IsTimeT(_XPLATSTR("31 Aug 1970 00:00:00 GMT"), (time_t)20908800);
-        TestRfc1123IsTimeT(_XPLATSTR("30 Sep 1970 00:00:00 GMT"), (time_t)23500800);
-        TestRfc1123IsTimeT(_XPLATSTR("31 Oct 1970 00:00:00 GMT"), (time_t)26179200);
-        TestRfc1123IsTimeT(_XPLATSTR("30 Nov 1970 00:00:00 GMT"), (time_t)28771200);
-        TestRfc1123IsTimeT(_XPLATSTR("31 Dec 1970 00:00:00 GMT"), (time_t)31449600);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Jan 1970 00:00:00 GMT"), 2592000);
+        TestRfc1123IsTimeT(_XPLATSTR("28 Feb 2019 00:00:00 GMT"), 1551312000); // non leap year allows feb 28
+        TestRfc1123IsTimeT(_XPLATSTR("29 Feb 2020 00:00:00 GMT"), 1582934400); // leap year allows feb 29
+        TestRfc1123IsTimeT(_XPLATSTR("31 Mar 1970 00:00:00 GMT"), 7689600);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Apr 1970 00:00:00 GMT"), 10281600);
+        TestRfc1123IsTimeT(_XPLATSTR("31 May 1970 00:00:00 GMT"), 12960000);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Jun 1970 00:00:00 GMT"), 15552000);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Jul 1970 00:00:00 GMT"), 18230400);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Aug 1970 00:00:00 GMT"), 20908800);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Sep 1970 00:00:00 GMT"), 23500800);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Oct 1970 00:00:00 GMT"), 26179200);
+        TestRfc1123IsTimeT(_XPLATSTR("30 Nov 1970 00:00:00 GMT"), 28771200);
+        TestRfc1123IsTimeT(_XPLATSTR("31 Dec 1970 00:00:00 GMT"), 31449600);
     }
 
     TEST(parsing_time_rfc1123_invalid_cases)
@@ -321,12 +315,9 @@ SUITE(datetime)
         // boundary cases:
         TestDateTimeRoundtrip(_XPLATSTR("1970-01-01T00:00:00Z"));                                         // epoch
         TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:14:06+00:00"), _XPLATSTR("2038-01-19T03:14:06Z")); // INT_MAX - 1
-        if (sizeof(time_t) == 8)
-        {
-            TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:13:07-00:01"),
-                                  _XPLATSTR("2038-01-19T03:14:07Z")); // INT_MAX after subtacting 1
-            TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:14:07-00:00"), _XPLATSTR("2038-01-19T03:14:07Z"));
-        }
+        TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:13:07-00:01"),
+                              _XPLATSTR("2038-01-19T03:14:07Z")); // INT_MAX after subtacting 1
+        TestDateTimeRoundtrip(_XPLATSTR("2038-01-19T03:14:07-00:00"), _XPLATSTR("2038-01-19T03:14:07Z"));
     }
 
     TEST(parsing_time_iso8601_uses_each_timezone_digit)

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -268,8 +268,7 @@ SUITE(datetime)
             _XPLATSTR("Thu, 01 Jan 1970 00:00:00 G"),
             _XPLATSTR("Thu, 01 Jan 1970 00:00:00 GM"),
             _XPLATSTR("Fri, 01 Jan 1970 00:00:00 GMT"), // wrong day
-            _XPLATSTR("01 Jan 4970 00:00:00 GMT"),      // year too big
-            _XPLATSTR("01 Jan 3001 00:00:00 GMT"),
+            _XPLATSTR("01 Jan 1899 00:00:00 GMT"), // year too small
             _XPLATSTR("01 Xxx 1971 00:00:00 GMT"), // month bad
             _XPLATSTR("00 Jan 1971 00:00:00 GMT"), // day too small
             _XPLATSTR("32 Jan 1971 00:00:00 GMT"), // day too big
@@ -290,13 +289,14 @@ SUITE(datetime)
             _XPLATSTR("01 Jan 1971 00:60:00 GMT"), // minute too big
             _XPLATSTR("01 Jan 1971 00:00:70 GMT"), // second too big
             _XPLATSTR("01 Jan 1971 00:00:61 GMT"),
-            _XPLATSTR("01 Jan 1969 00:00:00 GMT"),   // underflow
-            _XPLATSTR("01 Jan 1969 00:00:00 CEST"),  // bad tz
+            _XPLATSTR("01 Jan 1899 00:00:00 GMT"), // underflow
+            _XPLATSTR("01 Jan 1969 00:00:00 CEST"), // bad tz
             _XPLATSTR("01 Jan 1970 00:00:00 +2400"), // bad tzoffsets
             _XPLATSTR("01 Jan 1970 00:00:00 -3000"),
             _XPLATSTR("01 Jan 1970 00:00:00 +2160"),
             _XPLATSTR("01 Jan 1970 00:00:00 -2400"),
             _XPLATSTR("01 Jan 1970 00:00:00 -2160"),
+            _XPLATSTR("00 Jan 1971 00:00:00 GMT"), // zero month day
         };
 
         for (const auto& str : bad_strings)
@@ -435,8 +435,7 @@ SUITE(datetime)
             _XPLATSTR("1970-01-01T00:00:"),
             _XPLATSTR("1970-01-01T00:00:0"),
             // _XPLATSTR("1970-01-01T00:00:00"), // accepted as invalid timezone above
-            _XPLATSTR("4970-01-01T00:00:00Z"), // year too big
-            _XPLATSTR("3001-01-01T00:00:00Z"),
+            _XPLATSTR("1899-01-01T00:00:00Z"), // year too small
             _XPLATSTR("1971-00-01T00:00:00Z"), // month too small
             _XPLATSTR("1971-20-01T00:00:00Z"), // month too big
             _XPLATSTR("1971-13-01T00:00:00Z"),
@@ -459,15 +458,15 @@ SUITE(datetime)
             _XPLATSTR("1971-01-01T00:60:00Z"), // minute too big
             _XPLATSTR("1971-01-01T00:00:70Z"), // second too big
             _XPLATSTR("1971-01-01T00:00:61Z"),
-            _XPLATSTR("1969-01-01T00:00:00Z"),      // underflow
-            _XPLATSTR("3001-01-01T00:00:00Z"),      // overflow
-            _XPLATSTR("1970-01-01T00:00:00+00:01"), // time zone underflow
+            _XPLATSTR("1899-01-01T00:00:00Z"), // underflow
+            _XPLATSTR("1900-01-01T00:00:00+00:01"), // time zone underflow
             // _XPLATSTR("1970-01-01T00:00:00.Z"), // accepted as invalid timezone above
             _XPLATSTR("1970-01-01T00:00:00+24:00"), // bad tzoffsets
             _XPLATSTR("1970-01-01T00:00:00-30:00"),
             _XPLATSTR("1970-01-01T00:00:00+21:60"),
             _XPLATSTR("1970-01-01T00:00:00-24:00"),
             _XPLATSTR("1970-01-01T00:00:00-21:60"),
+            _XPLATSTR("1971-01-00"), // zero month day
         };
 
         for (const auto& str : bad_strings)


### PR DESCRIPTION
Update date formatting and parsing to accept all years between 1900 and 9999.

This unblocks the Azure Storage SDK which uses 9999-12-31 as a sentinel value for "no expiration time" which was broken by the locale insensitive date formatting's dependence on _mkgmtime, with its 1970-3000 range. By morally reimplementing _mkgmtime, this change also lets us remove the Android workaround of changing the TZ environment variable.

* Release\tests\functional\utils\datetime.cpp
  * Turn on tests for values that would need 64 bits represented as a time_t, even for 32 bit time_t platforms.
  * Add year 1900 and 9999 test cases, and remove year 3000+ and 1969- negative tests.

* Release\tests\functional\http\*
  * Drive by fix for new VS2019 warnings about narrowing.

* Release\src\utilities\asyncrt_utils.cpp
  * Remove dependence on _mkgmtime and gmtime_r/gmtime_s by implementing replacements loosely inspired by both the C runtime's date operations and .NET's handling of the Gregorian calendar's 400 year cycle.