### PR TITLE
json: {"meow"} is not a valid object

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -54,3 +54,6 @@ leetal
 
 Benjamin Lee (mobileben)
 René Meusel (reneme)
+
+Sony Corporation
+Gareth Sylvester-Bradley (garethsb-sony)

--- a/Release/src/json/json_parsing.cpp
+++ b/Release/src/json/json_parsing.cpp
@@ -965,7 +965,7 @@ std::unique_ptr<web::json::details::_Value> JSON_Parser<CharType>::_ParseObject(
             if (tkn.m_error) goto error;
 
             // State 2: Looking for a colon.
-            if (tkn.kind != JSON_Parser<CharType>::Token::TKN_Colon) goto done;
+            if (tkn.kind != JSON_Parser<CharType>::Token::TKN_Colon) goto error;
 
             GetNextToken(tkn);
             if (tkn.m_error) goto error;

--- a/Release/tests/functional/json/parsing_tests.cpp
+++ b/Release/tests/functional/json/parsing_tests.cpp
@@ -469,6 +469,12 @@ SUITE(parsing_tests)
         VERIFY_ARE_EQUAL(0u, arr.size());
     }
 
+    TEST(bug_object_field_key_no_value)
+    {
+        VERIFY_PARSING_THROW(json::value::parse(U("{\"meow\"}")));
+        VERIFY_PARSING_THROW(json::value::parse(U("{\"meow\": 42, \"purr\": 57, \"hiss\"}")));
+    }
+
     TEST(bug_416116)
     {
         json::value data2 = json::value::parse(U("\"δοκιμή\""));


### PR DESCRIPTION
Field keys *must* be followed by a colon and a value. At the moment, a lonely field key just terminates object parsing, without an error.

E.g.
 ```json
[{"meow"}, {"meow": 42, "purr": 57, "hiss"}]
```
previously parsed as if it were
```json
[{}, {"meow": 42, "purr": 57}]
```

I've added a test case to the json_test suite and the simple bug fix.