### PR TITLE
Remove the address_configured flag on tcp::resolver::query

### DIFF
--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -520,7 +520,9 @@ void hostport_listener::start()
     auto& service = crossplat::threadpool::shared_instance().service();
     tcp::resolver resolver(service);
     // #446: boost resolver does not recognize "+" as a host wildchar
-    tcp::resolver::query query = ("+" == m_host) ? tcp::resolver::query(m_port) : tcp::resolver::query(m_host, m_port);
+    tcp::resolver::query query = ("+" == m_host) ?
+        tcp::resolver::query(m_port, boost::asio::ip::resolver_query_base::flags()) :
+        tcp::resolver::query(m_host, m_port, boost::asio::ip::resolver_query_base::flags());
 
     tcp::endpoint endpoint = *resolver.resolve(query);
 


### PR DESCRIPTION
The default behavior for tcp::resolver::query uses the
address_configured flag, which only returns addresses if a non-loopback
address is available on the system. If this is called before a real network
interface is brought up, then resolution will fail and the server won't
be functional, even for requests on the loopback interface.

Explicitly set the flags to default so that the address_configured flag
is not specified. This allows the server to start up normally even when
the system has no active network interfaces.