### PR TITLE
Check that there are no user exceptions set before setting the value

### DIFF
--- a/Release/include/pplx/pplxtasks.h
+++ b/Release/include/pplx/pplxtasks.h
@@ -2708,7 +2708,7 @@ public:
     {
         // Subsequent sets are ignored. This makes races to set benign: the first setter wins and all others are
         // ignored.
-        if (_IsTriggered())
+        if (_IsTriggered() || _M_Impl->_HasUserException())
         {
             return false;
         }
@@ -2718,7 +2718,7 @@ public:
         {
             ::pplx::extensibility::scoped_critical_section_t _LockHolder(_M_Impl->_M_taskListCritSec);
 
-            if (!_IsTriggered())
+            if (!_IsTriggered() && !_M_Impl->_HasUserException())
             {
                 _M_Impl->_M_value.Set(_Result);
                 _M_Impl->_M_fHasValue = true;


### PR DESCRIPTION
Resolving a race condition where 1 thread attempts to set a value and another thread attempts to set an exception on the same `task_completion_event`. 
The problem is described in this issue: https://github.com/Microsoft/cpprestsdk/issues/256. 