### PR TITLE
Undefine compress if it is defined by zconf.h

### DIFF
--- a/Release/src/http/common/http_compression.cpp
+++ b/Release/src/http/common/http_compression.cpp
@@ -32,6 +32,10 @@
 
 #if defined(CPPREST_HTTP_COMPRESSION)
 #include <zlib.h>
+// zconf.h may define compress
+#ifdef compress
+#undef compress
+#endif
 #if !defined(CPPREST_EXCLUDE_BROTLI)
 #define CPPREST_BROTLI_COMPRESSION
 #endif // CPPREST_EXCLUDE_BROTLI


### PR DESCRIPTION
Fix for #1149.

Undef compress if it was set in [zconf.h](https://github.com/madler/zlib/blob/master/zconf.h) or a [similar file](https://github.com/chromium/chromium/blob/master/third_party/zlib/chromeconf.h).