### PR TITLE
Use EVP_MAX_MD_SIZE instead of HMAC_MAX_MD_CBLOCK

### DIFF
--- a/Release/src/http/oauth/oauth1.cpp
+++ b/Release/src/http/oauth/oauth1.cpp
@@ -136,7 +136,7 @@ std::vector<unsigned char> oauth1_config::_hmac_sha1(const utility::string_t& ke
 
 std::vector<unsigned char> oauth1_config::_hmac_sha1(const utility::string_t& key, const utility::string_t& data)
 {
-    unsigned char digest[HMAC_MAX_MD_CBLOCK];
+    unsigned char digest[EVP_MAX_MD_SIZE];
     unsigned int digest_len = 0;
 
     HMAC(EVP_sha1(),


### PR DESCRIPTION
Fix for #1154 .  Use EVP_MAX_MD_SIZE instead of HMAC_MAX_MD_CBLOCK per [HMAC Documentation](https://www.openssl.org/docs/man1.1.0/man3/HMAC.html).  Also enables the usage of cpprestsdk with [BoringSSL](https://github.com/google/boringssl/blob/master/include/openssl/hmac.h) which has removed HMAC_MAX_MD_CBLOCK from hmac.h in [this commit](https://github.com/google/boringssl/commit/582d2847eda65671883649347f60f6916838a3d1).