### PR TITLE
Fix broken CI Builds

### DIFF
--- a/Build_android/configure.sh
+++ b/Build_android/configure.sh
@@ -92,6 +92,8 @@ done
 
 # Variables setup
 
+unset BOOST_ROOT
+
 if [ ! -e "${ANDROID_NDK}/ndk-build" ]
 then
     echo "ANDROID_NDK does not point to a valid NDK."
@@ -153,7 +155,7 @@ if [ "${DO_OPENSSL}" == "1" ]; then (
 if [ "${DO_BOOST}" == "1" ]; then (
     if [ ! -d 'Boost-for-Android' ]; then git clone https://github.com/moritz-wundke/Boost-for-Android; fi
     cd Boost-for-Android
-    git checkout 1356b87fed389b4abf1ff671adec0b899877174b
+    git checkout b1e2cb397d3ec573f1cfdf4f4d965766204c53f1
     PATH="$PATH:$NDK_DIR" \
     CXXFLAGS="-std=gnu++11" \
     ./build-android.sh \

--- a/Build_iOS/configure.sh
+++ b/Build_iOS/configure.sh
@@ -73,8 +73,8 @@ while (( "$#" )); do
 done
 
 ## Configuration
-DEFAULT_BOOST_VERSION=1.67.0
-DEFAULT_OPENSSL_VERSION=1.0.2o
+DEFAULT_BOOST_VERSION=1.69.0
+DEFAULT_OPENSSL_VERSION=1.1.0k
 BOOST_VERSION=${BOOST_VERSION:-${DEFAULT_BOOST_VERSION}}
 OPENSSL_VERSION=${OPENSSL_VERSION:-${DEFAULT_OPENSSL_VERSION}}
 CPPRESTSDK_BUILD_TYPE=${CPPRESTSDK_BUILD_TYPE:-Release}
@@ -96,7 +96,7 @@ if [ ! -e $ABS_PATH/boost.framework ] && [ ! -d $ABS_PATH/boost ]; then
         git clone https://github.com/faithfracture/Apple-Boost-BuildScript ${ABS_PATH}/Apple-Boost-BuildScript
     fi
     pushd ${ABS_PATH}/Apple-Boost-BuildScript
-    git checkout 1b94ec2e2b5af1ee036d9559b96e70c113846392
+    git checkout 1ebe6e7654d9c9e1792076ee3827a45d5d2f34c5
     BOOST_LIBS="thread chrono filesystem regex system random" ./boost.sh -ios -tvos --boost-version $BOOST_VERSION
     popd
     mv ${ABS_PATH}/Apple-Boost-BuildScript/build/boost/${BOOST_VERSION}/ios/framework/boost.framework ${ABS_PATH}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,12 +161,18 @@ jobs:
         mkdir build.debug
         cd build.debug
         /usr/local/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ..
-        ninja
         cd ..
         mkdir build.release
         cd build.release
         /usr/local/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-        ninja
+        cd ..
+        ninja -C build.debug
+        ninja -C build.release
+        cd build.debug
+        ./test_runner *test.so
+        cd ..
+        cd build.release
+        ./test_runner *test.so
       displayName: Run build
   - job: Ubuntu_1604_Vcpkg
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,10 +168,9 @@ jobs:
         cd ..
         ninja -C build.debug
         ninja -C build.release
-        cd build.debug
+        cd build.debug/Release/Binaries
         ./test_runner *test.so
-        cd ..
-        cd build.release
+        cd ../../../build.release/Release/Binaries
         ./test_runner *test.so
       displayName: Run build
   - job: Ubuntu_1604_Vcpkg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,9 +153,10 @@ jobs:
       vmImage: 'Ubuntu 16.04'
     steps:
     - script: |
-        sudo apt-get install -y ppa-purge
+        sudo apt -y remove php*
+        sudo apt install -y ppa-purge
         sudo ppa-purge -y ppa:ondrej/php
-        sudo apt-get install -y libboost-atomic-dev libboost-thread-dev libboost-system-dev libboost-date-time-dev libboost-regex-dev libboost-filesystem-dev libboost-random-dev libboost-chrono-dev libboost-serialization-dev libwebsocketpp-dev openssl libssl-dev ninja-build
+        sudo apt install -y libboost-atomic-dev libboost-thread-dev libboost-system-dev libboost-date-time-dev libboost-regex-dev libboost-filesystem-dev libboost-random-dev libboost-chrono-dev libboost-serialization-dev libwebsocketpp-dev openssl libssl-dev ninja-build
       displayName: Apt install dependencies
     - script: |
         mkdir build.debug
@@ -191,8 +192,8 @@ jobs:
     steps:
     - script: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get -y update
-        sudo apt-get install g++-7 ninja-build -y
+        sudo apt -y update
+        sudo apt install g++-9 ninja-build -y
         ./vcpkg/bootstrap-vcpkg.sh
         ./vcpkg/vcpkg install zlib openssl boost-system boost-date-time boost-regex websocketpp boost-thread boost-filesystem boost-random boost-chrono boost-interprocess brotli --vcpkg-root ./vcpkg
       displayName: Vcpkg install dependencies
@@ -236,7 +237,7 @@ jobs:
       displayName: 'Build for Android'
   - job: MacOS_Homebrew
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
     steps:
     - script: brew install boost openssl ninja
       displayName: Brew install dependencies
@@ -279,7 +280,7 @@ jobs:
       displayName: 'Run ninja, release static'
   - job: MacOS_Vcpkg
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
     steps:
     - script: |
         brew install gcc ninja
@@ -316,7 +317,7 @@ jobs:
       displayName: 'Run tests, release'
   - job: MacOS_iOS
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
     steps:
     - script: |
         cd Build_iOS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,36 +156,18 @@ jobs:
         sudo apt -y remove php*
         sudo apt install -y ppa-purge
         sudo ppa-purge -y ppa:ondrej/php
+        unset BOOST_ROOT
         sudo apt install -y libboost-atomic-dev libboost-thread-dev libboost-system-dev libboost-date-time-dev libboost-regex-dev libboost-filesystem-dev libboost-random-dev libboost-chrono-dev libboost-serialization-dev libwebsocketpp-dev openssl libssl-dev ninja-build
-      displayName: Apt install dependencies
-    - script: |
         mkdir build.debug
-        mkdir build.release
-      displayName: Make Build Directories
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'build.debug'
-        cmakeArgs: '-G Ninja -DCMAKE_BUILD_TYPE=Debug ..'
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'build.release'
-        cmakeArgs: '-G Ninja -DCMAKE_BUILD_TYPE=Release ..'
-    - script: |
         cd build.debug
+        /usr/local/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ..
         ninja
-      displayName: 'Run ninja, debug'
-    - script: |
-        cd build.debug/Release/Binaries
-        ./test_runner *test.so
-      displayName: 'Run tests, debug'
-    - script: |
+        cd ..
+        mkdir build.release
         cd build.release
+        /usr/local/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
         ninja
-      displayName: 'Run ninja, release'
-    - script: |
-        cd build.release/Release/Binaries
-        ./test_runner *test.so
-      displayName: 'Run tests, release'
+      displayName: Run build
   - job: Ubuntu_1604_Vcpkg
     pool:
       vmImage: 'Ubuntu 16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -302,11 +302,12 @@ jobs:
         cd build.release/Release/Binaries
         ./test_runner *test.dylib
       displayName: 'Run tests, release'
-  - job: MacOS_iOS
-    pool:
-      vmImage: 'macOS-10.14'
-    steps:
-    - script: |
-        cd Build_iOS
-        ./configure.sh
-      displayName: 'Build for iOS'
+  # iOS is disabled for now because the dependency Apple-Boost-BuildScript appears to be broken with the version of XCode in use in Pipelines.
+  # - job: MacOS_iOS
+  #   pool:
+  #     vmImage: 'macOS-10.14'
+  #   steps:
+  #   - script: |
+  #       cd Build_iOS
+  #       ./configure.sh
+  #     displayName: 'Build for iOS'


### PR DESCRIPTION
Address a smorgasbord of issues caused by Azure Pipelines updating their hosted VMs out from underneath us:

* Azure pipelines deployed boost 1.69 into their VMs, but the version of GCC they have in that release hates that version of Boost. We unset `BOOST_ROOT` to use the default 1.58 version. We always want the version of boost in apt for the version of Ubuntu you get on Azure boxes to work with cpprestsdk, so we didn't want to jump through hoops to take the new 1.69 dependency here.
* Updated vcpkg and boost-for-android which fixed MacOS and Android builds, respectively due to MacOS and Android NDK updates.
* Disabled iOS for now because the Apple-Boost-BuildScript we use there appears to be unmaintained and broken on the XCode used in Pipelines; we would love to see contributors ( @mobileben ? ) who know what's going on flip this back on :)