### PR TITLE
FIX: SSL proxy tunnel support with basic auth

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -570,7 +570,7 @@ public:
 
             if (m_context->m_http_client->client_config().proxy().credentials().is_set())
             {
-                request_stream << m_context->generate_basic_proxy_auth_header() << CRLF;
+                request_stream << m_context->generate_basic_proxy_auth_header();
             }
 
             request_stream << CRLF;


### PR DESCRIPTION
The ASIO http client fails to connect to HTTPS endpoints via an HTTP proxy for some proxy server implementations, when using HTTP basic-auth for the connection to the proxy.

When connecting to an endpoint via an `ssl_proxy_tunnel` and using basic-auth for the proxy authentication, we experienced problems with certain proxy servers. Using `privoxy` everything worked fine, however `tinyproxy` didn't work.

After munching through quite a bit of Wireshark we figured out that the `CONNECT ... HTTP/1.1` request to the proxy was terminated by `\r\n\r\n\r\n`. I.e. one too many `\r\n`.

Some proxy implementations seem to drop this extra CRLF. Some others (e.g. `tinyproxy`) sent the extra CRLF as the first two bytes of payload to the endpoint. Obviously this screwed up the TLS handshake that was following.

It's fairly easy to reproduce this issue using the `bing_request` example. Just add the following to its proxy configuration and make it talk to `httpS://www.bing.com`:

```
auto proxy = web::web_proxy(env_http_proxy_string);
proxy.set_credentials(web::credentials("user", "password"));
client_config.set_proxy(proxy);
```