### PR TITLE
Remove trailing slash on websocketpp submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/Microsoft/vcpkg
 [submodule "websocketpp"]
 	path = Release/libs/websocketpp
-	url = https://github.com/zaphoyd/websocketpp/
+	url = https://github.com/zaphoyd/websocketpp
 	fetchRecurseSubmodules = false


### PR DESCRIPTION
remove trailing slash on websocketpp submodule url, which causes checkout failure on CircleCI with git 2.22.0