### PR TITLE
Discussion: Allow observation of JSON returned from TOKEN endpoint

### DIFF
--- a/Release/src/http/oauth/oauth2.cpp
+++ b/Release/src/http/oauth/oauth2.cpp
@@ -143,7 +143,7 @@ pplx::task<void> oauth2_config::_request_token(uri_builder& request_body_ub, ins
     return token_client.request(request)
         .then([](http_response resp) { return resp.extract_json(); })
         .then([this,inspect_func = std::move(inspect_func)](json::value json_resp) -> void {
-            inspect_func( json_resp );
+            inspect_func(json_resp);
             set_token(_parse_token_from_json(json_resp));
         });
 }


### PR DESCRIPTION
# What
implement mechanism to allow clients to inspect the JSON returned from the TOKEN endpoint, for use with services that return important data during this request

# Why
some services, such as Amazon Cognito, return additional tokens and other useful information during this call which we have no way of retrieving.

Creating this PR to generate some discussion around how we can accommodate this use case. I was trying to allow the client to insert a task to the pipeline, but pplx makes that tricky.