### PR TITLE
Implemented the stream operator<< for type datetime

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -57,3 +57,6 @@ René Meusel (reneme)
 
 Sony Corporation
 Gareth Sylvester-Bradley (garethsb-sony)
+
+Cubeware GmbH
+Peter Brockamp (pbrcw)

--- a/Release/include/cpprest/asyncrt_utils.h
+++ b/Release/include/cpprest/asyncrt_utils.h
@@ -628,13 +628,13 @@ public:
     bool operator==(datetime dt) const { return m_interval == dt.m_interval; }
 
     bool operator!=(const datetime& dt) const { return !(*this == dt); }
-   
+
     bool operator>(const datetime& dt) const { return this->m_interval > dt.m_interval; }
-   
+
     bool operator<(const datetime& dt) const { return this->m_interval < dt.m_interval; }
-      
+
     bool operator>=(const datetime& dt) const { return this->m_interval >= dt.m_interval; }
-   
+
     bool operator<=(const datetime& dt) const { return this->m_interval <= dt.m_interval; }
 
     static interval_type from_milliseconds(unsigned int milliseconds) { return milliseconds * _msTicks; }
@@ -664,6 +664,12 @@ private:
     // Storing as hundreds of nanoseconds 10e-7, i.e. 1 here equals 100ns.
     interval_type m_interval;
 };
+
+inline ::utility::ostream_t & operator<< (::utility::ostream_t & out, datetime const & data)
+{
+    out << data.to_string();
+    return out;
+}
 
 inline int operator-(datetime t1, datetime t2)
 {


### PR DESCRIPTION
This change enables the usage of type datetime as a key e. g. in an OData RESTful API implementation (Like the OData C++ Client Library that is build on top of Casablanca). Without this operator overload the attempt to do so would fail.