### PR TITLE
Enable HTTP compression support on all platforms

### DIFF
--- a/Release/src/http/common/http_compression.cpp
+++ b/Release/src/http/common/http_compression.cpp
@@ -268,7 +268,7 @@ public:
 class gzip_decompressor : public zlib_decompressor_base
 {
 public:
-    gzip_decompressor() : zlib_decompressor_base(16) // gzip auto-detect
+    gzip_decompressor() : zlib_decompressor_base(31) // 15 is MAX_WBITS in zconf.h; add 16 for gzip
     {
     }
 };

--- a/Release/src/http/common/http_compression.cpp
+++ b/Release/src/http/common/http_compression.cpp
@@ -17,18 +17,9 @@
 // it. CPPREST_EXCLUDE_BROTLI is set if we want to explicitly disable Brotli compression support.
 // CPPREST_EXCLUDE_WEBSOCKETS is a flag that now essentially means "no external dependencies". TODO: Rename
 
-#if __APPLE__
-#include "TargetConditionals.h"
-#if defined(TARGET_OS_MAC)
-#if !defined(CPPREST_EXCLUDE_COMPRESSION)
-#define CPPREST_HTTP_COMPRESSION
-#endif // !defined(CPPREST_EXCLUDE_COMPRESSION)
-#endif // defined(TARGET_OS_MAC)
-#elif defined(_WIN32) && (!defined(WINAPI_FAMILY) || WINAPI_PARTITION_DESKTOP)
 #if !defined(CPPREST_EXCLUDE_WEBSOCKETS) && !defined(CPPREST_EXCLUDE_COMPRESSION)
 #define CPPREST_HTTP_COMPRESSION
 #endif // !defined(CPPREST_EXCLUDE_WEBSOCKETS) && !defined(CPPREST_EXCLUDE_COMPRESSION)
-#endif
 
 #if defined(CPPREST_HTTP_COMPRESSION)
 #include <zlib.h>

--- a/Release/tests/functional/http/client/compression_tests.cpp
+++ b/Release/tests/functional/http/client/compression_tests.cpp
@@ -376,19 +376,31 @@ SUITE(compression_tests)
         }
     }
 
-    TEST_FIXTURE(uri_address, compress_and_decompress)
+    TEST_FIXTURE(uri_address, compress_and_decompress_fake)
     {
         compress_test(nullptr, nullptr); // FAKE
+    }
+
+    TEST_FIXTURE(uri_address, compress_and_decompress_gzip)
+    {
         if (builtin::algorithm::supported(builtin::algorithm::GZIP))
         {
             compress_test(builtin::get_compress_factory(builtin::algorithm::GZIP),
                           builtin::get_decompress_factory(builtin::algorithm::GZIP));
         }
+    }
+
+    TEST_FIXTURE(uri_address, compress_and_decompress_deflate)
+    {
         if (builtin::algorithm::supported(builtin::algorithm::DEFLATE))
         {
             compress_test(builtin::get_compress_factory(builtin::algorithm::DEFLATE),
                           builtin::get_decompress_factory(builtin::algorithm::DEFLATE));
         }
+    }
+
+    TEST_FIXTURE(uri_address, compress_and_decompress_brotli)
+    {
         if (builtin::algorithm::supported(builtin::algorithm::BROTLI))
         {
             compress_test(builtin::get_compress_factory(builtin::algorithm::BROTLI),


### PR DESCRIPTION
You can set CPPREST_EXCLUDE_COMPRESSION=ON to disable compression

Fix #1165