### PR TITLE
Fix tcp::resolver data race in the asio backend and be defensive against empty results

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -1050,6 +1050,10 @@ private:
         {
             report_error("Error resolving address", ec, httpclient_errorcode_context::connect);
         }
+        else if (endpoints == tcp::resolver::iterator())
+        {
+            report_error("Failed to resolve address", ec, httpclient_errorcode_context::connect);
+        }
         else
         {
             m_timer.reset();


### PR DESCRIPTION
Move TCP resolver to asio_context rather than asio_client, as that type is not safe to touch from multiple threads. @vinniefalco confirmed over Twitter that constructing resolvers is cheap https://twitter.com/FalcoVinnie/status/1230780333613670401