### PR TITLE
Fix uncaught exception

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -333,7 +333,8 @@ public:
     void enable_no_delay()
     {
         boost::asio::ip::tcp::no_delay option(true);
-        m_socket.set_option(option);
+        boost::system::error_code error_ignored;
+        m_socket.set_option(option, error_ignored);
     }
 
 private:

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -594,7 +594,8 @@ void hostport_listener::on_accept(std::unique_ptr<ip::tcp::socket> socket, const
     if (!ec)
     {
         boost::asio::ip::tcp::no_delay option(true);
-        socket->set_option(option);
+        boost::system::error_code error_ignored;
+        socket->set_option(option, error_ignored);
 
         auto conn = asio_server_connection::create(std::move(socket), m_p_server, this);
 


### PR DESCRIPTION
PR #1310 added TCP_NODELAY as a performance optimization to ASIO-based `http_client` and `http_listener`. Unfortunately, the innocent-looking `set_option` can throw `boost::system::system_error`, which was not handled and therefore results in `std::terminate`.

I've never seen this happen on various Windows and Linux environments, but on a macOS VM we have now seen the `http_client`-side issue if the server closes the socket with just the right timing. It's hard to test, often takes 10 minutes in that environment.

My approach here is to ignore errors (we've seen EBADF and EINVAL), since this is a performance optimization only, and hard errors will be picked up by the write operation on the socket which follows immediately.
