### PR TITLE
Allow disabling SSL certificate revocation checks

### DIFF
--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -99,7 +99,8 @@ public:
         , m_chunksize(0)
         , m_request_compressed(false)
 #if !defined(__cplusplus_winrt)
-        , m_validate_certificates(true)
+        , m_validate_certificates(true),
+        , m_check_ssl_certificate_revocation(true)
 #endif
 #if !defined(_WIN32) && !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
         , m_tlsext_sni_enabled(true)
@@ -262,6 +263,19 @@ public:
     /// otherwise.</param> <remarks>Note ignoring certificate errors can be dangerous and should be done with
     /// caution.</remarks>
     void set_validate_certificates(bool validate_certs) { m_validate_certificates = validate_certs; }
+
+    /// <summary>
+    /// Gets the enable SSL revocation property.
+    /// </summary>
+    /// <returns>True if certificates revocation is to be checked, false otherwise.</returns>
+    bool check_ssl_certificate_revocation() const { return m_check_ssl_certificate_revocation; }
+
+    /// <summary>
+    /// Sets the enable SSL revocation property.
+    /// </summary>
+    /// <param name="check_ssl_certificate_revocation">True to check certificate validation, false to skip these checks.</param>
+    /// <remarks>Note ignoring certificate revocation can be dangerous and should be done with caution.</remarks>
+    void set_check_ssl_certificate_revocation(bool check_ssl_certificate_revocation) { m_check_ssl_certificate_revocation = check_ssl_certificate_revocation; }
 #endif
 
 #if (defined(_WIN32) && !defined(__cplusplus_winrt)) || defined(CPPREST_FORCE_HTTP_CLIENT_WINHTTPPAL)
@@ -414,6 +428,7 @@ private:
 #if !defined(__cplusplus_winrt)
     // IXmlHttpRequest2 doesn't allow configuration of certificate verification.
     bool m_validate_certificates;
+    bool m_check_ssl_certificate_revocation;
 #endif
 
     std::function<void(native_handle)> m_set_user_nativehandle_options;

--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -1091,16 +1091,19 @@ protected:
         DWORD ignoredCertificateValidationSteps = 0;
         if (client_config().validate_certificates())
         {
-            // if we are validating certificates, also turn on revocation checking
-            DWORD dwEnableSSLRevocationOpt = WINHTTP_ENABLE_SSL_REVOCATION;
-            if (!WinHttpSetOption(winhttp_context->m_request_handle,
-                                  WINHTTP_OPTION_ENABLE_FEATURE,
-                                  &dwEnableSSLRevocationOpt,
-                                  sizeof(dwEnableSSLRevocationOpt)))
+            // Check to see if we are checking certificate revocation as well
+            if (client_config().check_ssl_certificate_revocation())
             {
-                auto errorCode = GetLastError();
-                request->report_error(errorCode, build_error_msg(errorCode, "Error enabling SSL revocation check"));
-                return;
+	            DWORD dwEnableSSLRevocationOpt = WINHTTP_ENABLE_SSL_REVOCATION;
+	            if (!WinHttpSetOption(winhttp_context->m_request_handle,
+	                                  WINHTTP_OPTION_ENABLE_FEATURE,
+	                                  &dwEnableSSLRevocationOpt,
+	                                  sizeof(dwEnableSSLRevocationOpt)))
+	            {
+	                auto errorCode = GetLastError();
+	                request->report_error(errorCode, build_error_msg(errorCode, "Error enabling SSL revocation check"));
+	                return;
+	            }
             }
 
             // check if the user has overridden the desired Common Name with the host header


### PR DESCRIPTION
Preamble: this is my first real contribution, so if you will have patience with me and be kind, I would appreciate it.

This change adds a new property to http_client to allow disabling certificate revocation independently even if certificate validation is turned on.

A comment was left on PR #687:
[In my opinion, a complete solution to issue #664 would also allow disabling certificate revocation checking without completely disabling certificate validation as well.](
https://github.com/microsoft/cpprestsdk/pull/687#issuecomment-387291622_)

This should more fully resolve issue #664

Note: This only applies to http_client, not websockets or asio. Those use boost and I am not sure if it allows toggling this the way WinHttp does.