### PR TITLE
SSL support for Linux clients

### DIFF
--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -445,7 +445,7 @@ bool verify_X509_cert_chain(const std::vector<std::string>& certChain, const std
 }
 #endif
 
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__)
 bool verify_X509_cert_chain(const std::vector<std::string>& certChain, const std::string& hostName)
 {
     // find system certificates

--- a/Release/src/http/client/x509_cert_utilities.cpp
+++ b/Release/src/http/client/x509_cert_utilities.cpp
@@ -445,7 +445,7 @@ bool verify_X509_cert_chain(const std::vector<std::string>& certChain, const std
 }
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__ANDROID__)
 bool verify_X509_cert_chain(const std::vector<std::string>& certChain, const std::string& hostName)
 {
     // find system certificates


### PR DESCRIPTION
Add x509 certificate chain validation for HTTP client on Linux OS