### PR TITLE
Fix configuration failure on Mac when OPENSSL_ROOT_DIR is empty

### DIFF
--- a/Release/cmake/cpprest_find_openssl.cmake
+++ b/Release/cmake/cpprest_find_openssl.cmake
@@ -35,9 +35,12 @@ function(cpprest_find_openssl)
       if(NOT DEFINED OPENSSL_ROOT_DIR)
         # Prefer a homebrew version of OpenSSL over the one in /usr/lib
         file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl*/*)
-        # Prefer the latest (make the latest one first)
-        list(REVERSE OPENSSL_ROOT_DIR)
-        list(GET OPENSSL_ROOT_DIR 0 OPENSSL_ROOT_DIR)
+
+        if(OPENSSL_ROOT_DIR)
+          # Prefer the latest (make the latest one first)
+          list(REVERSE OPENSSL_ROOT_DIR)
+          list(GET OPENSSL_ROOT_DIR 0 OPENSSL_ROOT_DIR)
+        endif()
       endif()
       # This should prevent linking against the system provided 0.9.8y
       message(STATUS "OPENSSL_ROOT_DIR = ${OPENSSL_ROOT_DIR}")


### PR DESCRIPTION
On my Mac (10.14.6, no Homebrew installed), I was receiving the following error when attempting to use the vcpkg-provided OpenSSL to build C++ REST SDK:

```
CMake Error at cmake/cpprest_find_openssl.cmake:40 (list):
  list GET given empty list
Call Stack (most recent call first):
  src/CMakeLists.txt:130 (cpprest_find_openssl)
```

This patch fixes the issue for me.