### PR TITLE
Feature: Always open a stream with FILE_SHARE_DELETE

### DIFF
--- a/Release/src/streams/fileio_win32.cpp
+++ b/Release/src/streams/fileio_win32.cpp
@@ -147,13 +147,21 @@ void _get_create_flags(
     }
 
     // C++ specifies what permissions to deny, Windows which permissions to give,
-    dwShareMode = 0x3;
-    switch (prot)
-    {
-        case _SH_DENYRW: dwShareMode = 0x0; break;
-        case _SH_DENYWR: dwShareMode = 0x1; break;
-        case _SH_DENYRD: dwShareMode = 0x2; break;
+    dwShareMode = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    switch (prot) {
+    case _SH_DENYRW:
+        dwShareMode = 0x0;
+        break;
+    case _SH_DENYWR:
+        dwShareMode = FILE_SHARE_READ;
+        break;
+    case _SH_DENYRD:
+        dwShareMode = FILE_SHARE_WRITE;
+        break;
     }
+
+    // according to the post of: https://github.com/golang/go/issues/32088#issuecomment-502850674
+    dwShareMode |= FILE_SHARE_DELETE;
 }
 
 /// <summary>


### PR DESCRIPTION
According to a post of a Microsoft Team-Member, I guess the way we want to open streams is using the FILE_SHARE_DELETE flag always. (https://github.com/golang/go/issues/32088#issuecomment-502850674) I don't see any reason, why we should not open a stream with it, especially in case we don't want to block the file at all. The discussions started here: https://github.com/microsoft/cpprestsdk/issues/1473.