### PR TITLE
Show low-level error message for OpenSSL errors

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -966,7 +966,7 @@ private:
         return header;
     }
 
-    void report_error(const std::string& message,
+    void report_error(std::string&& message,
                       const boost::system::error_code& ec,
                       httpclient_errorcode_context context = httpclient_errorcode_context::none)
     {
@@ -1005,6 +1005,17 @@ private:
                 default: break;
             }
         }
+
+        // SSL error codes may contain valuable information, so append it to
+        // the message if available.
+        if (ec.category() == boost::asio::error::ssl_category ||
+            ec.category() == boost::asio::ssl::error::stream_category)
+        {
+          message += " (";
+          message += ec.message();
+          message += ")";
+        }
+
         request_context::report_error(errorcodeValue, message);
     }
 


### PR DESCRIPTION
Such errors may contain valuable information and we shouldn't just lose
it completely as happened before.

---

This is as simple as it gets, but allows to see messages like "Error in SSL handshake (certificate verify failed)" instead of just the part before the parentheses, which can be pretty invaluable when trying to diagnose a problem (in this case due to a proxy mounting a MitM attack on the connection...). Perhaps the error message should be included for other errors too, but it definitely should be done for those ones.