### PR TITLE
Fix year calculation for the last day of a leap year.

### DIFF
--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -736,6 +736,12 @@ static compute_year_result compute_year(int64_t secondsSince1900)
     int secondsInt = static_cast<int>(secondsLeft - year4 * SecondsIn4Years);
 
     int year1 = secondsInt / SecondsInYear;
+    if (year1 == 4)
+    {
+        // this is the last day in a leap year
+        year1 = 3;
+    }
+
     secondsInt -= year1 * SecondsInYear;
 
     // shift back to 1900 base from 1601:

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -133,6 +133,21 @@ SUITE(datetime)
         TestDateTimeRoundtrip(_XPLATSTR("9999-12-31T23:59:59Z"));
     }
 
+    TEST(parsing_time_roundtrip_year_2016)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("2016-12-31T20:59:59Z"));
+    }
+
+    TEST(parsing_time_roundtrip_year_2020)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("2020-12-31T20:59:59Z"));
+    }
+
+    TEST(parsing_time_roundtrip_year_2021)
+    {
+        TestDateTimeRoundtrip(_XPLATSTR("2021-01-01T20:59:59Z"));
+    }
+
     TEST(emitting_time_correct_day) {
         const auto test = utility::datetime() + UINT64_C(132004507640000000); // 2019-04-22T23:52:44 is a Monday
         const auto actual = test.to_string(utility::datetime::RFC_1123);


### PR DESCRIPTION
`calculate_year` determines the year by following the gregorian calendar's rules of breaking years into 400, 100, and 4 year cycles. However, it has an edge case where the current year is the last day of a leap year, such that `SecondsIn4Years` contains that extra leap day but the calculation of `year` didn't account for the current date being exactly that extra day.

Since we expect anything in a 4 year cycle to be handled by `SecondsIn4Years`, if `year` ends up being 4, we know it is that last day of a leap year, and as such get the correct result by using 3 instead. The subsequent code that uses a month day table according to a year's leap-ness then handles the result correctly.