### PR TITLE
Support mingw-w64 (from msys2) on Windows.

### DIFF
--- a/Release/CMakeLists.txt
+++ b/Release/CMakeLists.txt
@@ -15,13 +15,32 @@ set(CPPREST_VERSION_REVISION 17)
 
 enable_testing()
 
-set(WERROR ON CACHE BOOL "Treat Warnings as Errors.")
+if(MINGW)
+  # on mingw there are tons of warnings.
+  set(WERROR OFF CACHE BOOL "Treat Warnings as Errors.")
+else()
+  set(WERROR ON CACHE BOOL "Treat Warnings as Errors.")
+endif()
 set(CPPREST_EXCLUDE_WEBSOCKETS OFF CACHE BOOL "Exclude websockets functionality.")
 set(CPPREST_EXCLUDE_COMPRESSION OFF CACHE BOOL "Exclude compression functionality.")
 set(CPPREST_EXCLUDE_BROTLI ON CACHE BOOL "Exclude Brotli compression functionality.")
 set(CPPREST_EXPORT_DIR cmake/cpprestsdk CACHE STRING "Directory to install CMake config files.")
 set(CPPREST_INSTALL_HEADERS ON CACHE BOOL "Install header files.")
 set(CPPREST_INSTALL ON CACHE BOOL "Add install commands.")
+
+SET(DEFAULT_BUILD_TYPE "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# There's a "string table overflow" with mingw-w64 when optimization is disabled.
+#
+# see also: https://stackoverflow.com/questions/14125007/gcc-string-table-overflow-error-during-compilation
+if(MINGW AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message(FATAL_ERROR "mingw-w64 cannot build the debug version of this library")
+endif()
 
 if(IOS OR ANDROID)
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
@@ -92,6 +111,12 @@ if(APPLE) # Note: also iOS
   set(CPPREST_HTTP_CLIENT_IMPL asio CACHE STRING "Internal use.")
   set(CPPREST_HTTP_LISTENER_IMPL asio CACHE STRING "Internal use.")
 elseif(UNIX AND NOT APPLE) # Note: also android
+  set(CPPREST_PPLX_IMPL linux CACHE STRING "Internal use.")
+  set(CPPREST_WEBSOCKETS_IMPL wspp CACHE STRING "Internal use.")
+  set(CPPREST_FILEIO_IMPL posix CACHE STRING "Internal use.")
+  set(CPPREST_HTTP_CLIENT_IMPL asio CACHE STRING "Internal use.")
+  set(CPPREST_HTTP_LISTENER_IMPL asio CACHE STRING "Internal use.")
+elseif(MINGW)
   set(CPPREST_PPLX_IMPL linux CACHE STRING "Internal use.")
   set(CPPREST_WEBSOCKETS_IMPL wspp CACHE STRING "Internal use.")
   set(CPPREST_FILEIO_IMPL posix CACHE STRING "Internal use.")
@@ -169,8 +194,12 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -D_GLIBCXX_USE_SCHED_YIELD -D_GLIBCXX_USE_NANOSLEEP")
+  if (MINGW)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
+  else()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -D_GLIBCXX_USE_SCHED_YIELD -D_GLIBCXX_USE_NANOSLEEP")
+    endif()
   endif()
 
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/Release/include/cpprest/details/SafeInt3.hpp
+++ b/Release/include/cpprest/details/SafeInt3.hpp
@@ -152,8 +152,23 @@ Please read the leading comments before using the class.
 
 #ifndef C_ASSERT
 #define C_ASSERT_DEFINED_SAFEINT
+#if defined(__MINGW32__)
+#define C_ASSERT(e) void __C_ASSERT__(int [(e)?1:-1])
+#else // defined(__MINGW32__)
 #define C_ASSERT(e) typedef char __C_ASSERT__[(e) ? 1 : -1]
-#endif
+#endif // defined(__MINGW32__)
+#else
+#if defined(__MINGW32__)
+// the default definition from mingw is: extern void __C_ASSERT__(int [(e)?1:-1])
+//
+// When be used in class declration the compiler will complains: error: storage class specified for '__C_ASSERT__'.
+// See also: https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-tools/widl/include/winnt.h
+//
+// But we cannot define it as `typedef char __C_ASSERT__[(e) ? 1 : -1]`, since it may conflict with the system's one.
+#undef C_ASSERT
+#define C_ASSERT(e) void __C_ASSERT__(int [(e)?1:-1])
+#endif // defined(__MINGW32__)
+#endif // C_ASSERT
 
 // Let's test some assumptions
 // We're assuming two's complement negative numbers

--- a/Release/include/cpprest/details/basic_types.h
+++ b/Release/include/cpprest/details/basic_types.h
@@ -32,7 +32,7 @@
 
 namespace utility
 {
-#ifdef _WIN32
+#if defined(_WIN32)
 #define _UTF16_STRINGS
 #endif
 

--- a/Release/include/cpprest/details/cpprest_compat.h
+++ b/Release/include/cpprest/details/cpprest_compat.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 
 #if _MSC_VER >= 1900
 #define CPPREST_NOEXCEPT noexcept
@@ -69,7 +69,7 @@
 #endif // __clang__
 #endif // _WIN32
 
-#ifdef _NO_ASYNCRTIMP
+#if defined(_NO_ASYNCRTIMP) || defined(__MINGW32__)
 #define _ASYNCRTIMP
 #else // ^^^ _NO_ASYNCRTIMP ^^^ // vvv !_NO_ASYNCRTIMP vvv
 #ifdef _ASYNCRT_EXPORT

--- a/Release/include/cpprest/filestream.h
+++ b/Release/include/cpprest/filestream.h
@@ -714,7 +714,7 @@ private:
     static pplx::task<std::shared_ptr<basic_streambuf<_CharType>>> open(
         const utility::string_t& _Filename,
         std::ios_base::openmode _Mode = std::ios_base::out,
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
         int _Prot = (int)std::ios_base::_Openprot
 #else
         int _Prot = 0                                         // unsupported on Linux, for now
@@ -956,7 +956,7 @@ public:
     /// <returns>A <c>task</c> that returns an opened stream buffer on completion.</returns>
     static pplx::task<streambuf<_CharType>> open(const utility::string_t& file_name,
                                                  std::ios_base::openmode mode = std::ios_base::out,
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
                                                  int prot = _SH_DENYRD
 #else
                                                  int prot = 0 // unsupported on Linux
@@ -1011,7 +1011,7 @@ public:
     /// <returns>A <c>task</c> that returns an opened input stream on completion.</returns>
     static pplx::task<streams::basic_istream<_CharType>> open_istream(const utility::string_t& file_name,
                                                                       std::ios_base::openmode mode = std::ios_base::in,
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
                                                                       int prot = (int)std::ios_base::_Openprot
 #else
                                                                       int prot = 0
@@ -1036,7 +1036,7 @@ public:
     /// <returns>A <c>task</c> that returns an opened output stream on completion.</returns>
     static pplx::task<streams::basic_ostream<_CharType>> open_ostream(const utility::string_t& file_name,
                                                                       std::ios_base::openmode mode = std::ios_base::out,
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
                                                                       int prot = (int)std::ios_base::_Openprot
 #else
                                                                       int prot = 0

--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -112,7 +112,7 @@ class status_codes
 {
 public:
 #define _PHRASES
-#define DAT(a, b, c) const static status_code a = b;
+#define DAT(a, b, c) _ASYNCRTIMP const static status_code a = b;
 #include "cpprest/details/http_constants.dat"
 #undef _PHRASES
 #undef DAT

--- a/Release/include/cpprest/json.h
+++ b/Release/include/cpprest/json.h
@@ -403,7 +403,7 @@ public:
     /// <returns>The parsed object. Returns web::json::value::null if failed</returns>
     _ASYNCRTIMP static value __cdecl parse(const utility::string_t& value, std::error_code& errorCode);
 
-#ifdef _WIN32
+#if defined(_WIN32)
     /// <summary>
     /// Parses a string and construct a JSON value.
     /// </summary>

--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -1723,7 +1723,7 @@ private:
 
 #ifdef _WIN32
 template<class CharType>
-class type_parser<CharType, std::enable_if_t<sizeof(CharType) == 1, std::basic_string<wchar_t>>>
+class type_parser<CharType, typename std::enable_if<sizeof(CharType) == 1, std::basic_string<wchar_t>>::type>
     : public _type_parser_base<CharType>
 {
     typedef _type_parser_base<CharType> base;

--- a/Release/include/pplx/pplx.h
+++ b/Release/include/pplx/pplx.h
@@ -26,7 +26,7 @@
 #endif
 #endif // _WIN32
 
-#ifdef _NO_PPLXIMP
+#if defined(_NO_PPLXIMP) || defined(__MINGW32__)
 #define _PPLXIMP
 #else
 #ifdef _PPLX_EXPORT
@@ -40,7 +40,11 @@
 
 // Use PPLx
 #ifdef _WIN32
+#if defined(__MINGW32__)
+#include "pplx/pplxlinux.h"
+#else
 #include "pplx/pplxwin.h"
+#endif // defined(__MINGW32__)
 #elif defined(__APPLE__)
 #undef _PPLXIMP
 #define _PPLXIMP

--- a/Release/include/pplx/pplxinterface.h
+++ b/Release/include/pplx/pplxinterface.h
@@ -22,7 +22,7 @@
 
 #if defined(_CRTBLD)
 #elif defined(_WIN32)
-#if (_MSC_VER >= 1700)
+#if (_MSC_VER >= 1700) || defined(__MINGW32__)
 #define _USE_REAL_ATOMICS
 #endif
 #else // GCC compiler

--- a/Release/include/pplx/pplxlinux.h
+++ b/Release/include/pplx/pplxlinux.h
@@ -13,11 +13,11 @@
 
 #pragma once
 
-#if (defined(_MSC_VER))
+#if defined(_MSC_VER) && !defined(__MINGW32__)
 #error This file must not be included for Visual Studio
 #endif
 
-#ifndef _WIN32
+#if !defined(__cplusplus_winrt)
 
 #include "cpprest/details/cpprest_compat.h"
 #include "pthread.h"
@@ -259,12 +259,20 @@ namespace details
 /// Terminate the process due to unhandled exception
 /// </summary>
 #ifndef _REPORT_PPLTASK_UNOBSERVED_EXCEPTION
+#if defined(__MINGW32__)
+#define _REPORT_PPLTASK_UNOBSERVED_EXCEPTION()                                                                         \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        std::terminate();                                                                                              \
+    } while (false)
+#else
 #define _REPORT_PPLTASK_UNOBSERVED_EXCEPTION()                                                                         \
     do                                                                                                                 \
     {                                                                                                                  \
         raise(SIGTRAP);                                                                                                \
         std::terminate();                                                                                              \
     } while (false)
+#endif // defined(__MINGW32__)
 #endif //_REPORT_PPLTASK_UNOBSERVED_EXCEPTION
 } // namespace details
 
@@ -274,4 +282,4 @@ __attribute__((always_inline)) inline void* _ReturnAddress() { return __builtin_
 
 } // namespace pplx
 
-#endif // !_WIN32
+#endif // !defined(__cplusplus_winrt)

--- a/Release/samples/BingRequest/CMakeLists.txt
+++ b/Release/samples/BingRequest/CMakeLists.txt
@@ -1,4 +1,8 @@
 if (NOT WINDOWS_STORE AND NOT WINDOWS_PHONE)
   add_executable(BingRequest bingrequest.cpp)
   target_link_libraries(BingRequest cpprest)
+
+  if(MINGW)
+    target_link_libraries(BingRequest ws2_32 wsock32)
+  endif()
 endif()

--- a/Release/samples/BlackJack/BlackJack_Client/BlackJackClient.cpp
+++ b/Release/samples/BlackJack/BlackJack_Client/BlackJackClient.cpp
@@ -157,7 +157,7 @@ void PrintTable(const http_response& response, bool& refresh)
 // Arguments: BlackJack_Client.exe <port>
 // If port is not specified, client will assume that the server is listening on port 34568
 //
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 int wmain(int argc, wchar_t* argv[])
 #else
 int main(int argc, char* argv[])

--- a/Release/samples/BlackJack/BlackJack_Client/CMakeLists.txt
+++ b/Release/samples/BlackJack/BlackJack_Client/CMakeLists.txt
@@ -7,3 +7,7 @@ add_executable(blackjackclient
   )
 
 target_link_libraries(blackjackclient cpprest)
+
+if(MINGW)
+  target_link_libraries(blackjackclient ws2_32 wsock32)
+endif()

--- a/Release/samples/BlackJack/BlackJack_Server/BlackJack_Server.cpp
+++ b/Release/samples/BlackJack/BlackJack_Server/BlackJack_Server.cpp
@@ -63,7 +63,7 @@ void on_shutdown()
 // BlackJack_Server.exe <port>
 // If port is not specified, will listen on 34568
 //
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 int wmain(int argc, wchar_t* argv[])
 #else
 int main(int argc, char* argv[])

--- a/Release/samples/BlackJack/BlackJack_Server/CMakeLists.txt
+++ b/Release/samples/BlackJack/BlackJack_Server/CMakeLists.txt
@@ -9,5 +9,8 @@ add_executable(blackjackserver
   )
 
 target_link_libraries(blackjackserver cpprest)
+if(MINGW)
+  target_link_libraries(blackjackserver ws2_32 wsock32)
+endif()
 
 configure_pch(blackjackserver stdafx.h stdafx.cpp /Zm120)

--- a/Release/samples/BlackJack/BlackJack_Server/Table.h
+++ b/Release/samples/BlackJack/BlackJack_Server/Table.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "stdafx.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <concrt.h>
 #endif
 #include "messagetypes.h"

--- a/Release/samples/CasaLens/casalens.cpp
+++ b/Release/samples/CasaLens/casalens.cpp
@@ -130,7 +130,7 @@ void CasaLens::handle_post(http_request message)
     }
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 int wmain(int argc, wchar_t* args[])
 #else
 int main(int argc, char* args[])

--- a/Release/samples/Oauth1Client/CMakeLists.txt
+++ b/Release/samples/Oauth1Client/CMakeLists.txt
@@ -4,4 +4,8 @@ if (NOT WINDOWS_STORE AND NOT WINDOWS_PHONE)
     )
 
   target_link_libraries(oauth1client cpprest)
+
+  if(MINGW)
+    target_link_libraries(oauth1client ws2_32 wsock32)
+  endif()
 endif()

--- a/Release/samples/Oauth1Client/Oauth1Client.cpp
+++ b/Release/samples/Oauth1Client/Oauth1Client.cpp
@@ -279,7 +279,7 @@ protected:
     }
 };
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 int wmain(int argc, wchar_t* argv[])
 #else
 int main(int argc, char* argv[])

--- a/Release/samples/Oauth2Client/CMakeLists.txt
+++ b/Release/samples/Oauth2Client/CMakeLists.txt
@@ -4,4 +4,8 @@ if (NOT WINDOWS_STORE AND NOT WINDOWS_PHONE)
     )
 
   target_link_libraries(oauth2client cpprest)
+
+  if(MINGW)
+    target_link_libraries(oauth2client ws2_32 wsock32)
+  endif()
 endif()

--- a/Release/samples/Oauth2Client/Oauth2Client.cpp
+++ b/Release/samples/Oauth2Client/Oauth2Client.cpp
@@ -292,7 +292,7 @@ protected:
     }
 };
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 int wmain(int argc, wchar_t* argv[])
 #else
 int main(int argc, char* argv[])

--- a/Release/samples/SearchFile/searchfile.cpp
+++ b/Release/samples/SearchFile/searchfile.cpp
@@ -151,7 +151,7 @@ static pplx::task<void> write_matches_to_file(const string_t& fileName, matched_
     });
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 int wmain(int argc, wchar_t* args[])
 #else
 int main(int argc, char* args[])
@@ -162,9 +162,9 @@ int main(int argc, char* args[])
         printf("Usage: SearchFile.exe input_file search_string output_file\n");
         return -1;
     }
-    const string_t inFileName = args[1];
+    const string_t inFileName = utility::conversions::to_string_t(args[1]);
     const std::string searchString = utility::conversions::to_utf8string(args[2]);
-    const string_t outFileName = args[3];
+    const string_t outFileName = utility::conversions::to_string_t(args[3]);
     producer_consumer_buffer<char> lineResultsBuffer;
 
     // Find all matches in file.

--- a/Release/src/CMakeLists.txt
+++ b/Release/src/CMakeLists.txt
@@ -213,6 +213,12 @@ if (WIN32 AND NOT WINDOWS_STORE AND NOT WINDOWS_PHONE)
     bcrypt.lib
     crypt32.lib
   )
+  if(MINGW)
+    target_link_libraries(cpprest PRIVATE
+      ws2_32
+      wsock32
+    )
+  endif()
 elseif(WINDOWS_STORE)
   if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
     target_compile_definitions(cpprest PRIVATE -DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP)

--- a/Release/src/http/listener/http_server_httpsys.cpp
+++ b/Release/src/http/listener/http_server_httpsys.cpp
@@ -1257,7 +1257,9 @@ void windows_request_context::cancel_request(std::exception_ptr except_ptr)
     }
 }
 
-std::unique_ptr<http_server> make_http_httpsys_server() { return std::make_unique<http_windows_server>(); }
+std::unique_ptr<http_server> make_http_httpsys_server() {
+    return std::unique_ptr<http_windows_server>(new http_windows_server());
+}
 
 } // namespace details
 } // namespace experimental

--- a/Release/src/json/json_parsing.cpp
+++ b/Release/src/json/json_parsing.cpp
@@ -372,7 +372,12 @@ static double anystod(const char* str)
 }
 static double anystod(const wchar_t* str)
 {
+#if defined(__MINGW32__)
+    // link error on mingw-w64: undefined reference to `__imp__wcstod_l'
+    return wcstod(str, nullptr);
+#else
     return _wcstod_l(str, nullptr, utility::details::scoped_c_thread_locale::c_locale());
+#endif
 }
 #else
 static int __attribute__((__unused__)) print_llu(char* ptr, size_t n, unsigned long long val64)

--- a/Release/src/json/json_serialization.cpp
+++ b/Release/src/json/json_serialization.cpp
@@ -160,8 +160,11 @@ void web::json::details::_Number::format(std::basic_string<char>& stream) const
             _i64toa_s(m_number.m_intval, tempBuffer, tempSize, 10);
         else
             _ui64toa_s(m_number.m_uintval, tempBuffer, tempSize, 10);
-
+#if defined(__MINGW32__)
+        const auto numChars = strnlen(tempBuffer, tempSize);
+#else
         const auto numChars = strnlen_s(tempBuffer, tempSize);
+#endif // defined(__MINGW32__)
 #else
         int numChars;
         if (m_number.m_type == number::type::signed_type)

--- a/Release/src/pch/stdafx.h
+++ b/Release/src/pch/stdafx.h
@@ -42,7 +42,9 @@
 #include <winhttp.h>
 #endif // !__cplusplus_winrt
 
-#else // LINUX or APPLE
+#endif // _WIN32
+
+#if !defined(_WIN32) || defined(__MINGW32__) // LINUX, APPLE or MinGW
 #define __STDC_LIMIT_MACROS
 #include "pthread.h"
 #include <atomic>
@@ -62,9 +64,14 @@
 #include "boost/thread/mutex.hpp"
 #include <fcntl.h>
 #include <sys/stat.h>
+#if !defined(__MINGW32__)
 #include <sys/syscall.h>
+#endif
 #include <unistd.h>
-#endif // _WIN32
+#endif // !defined(_WIN32) || defined(__MINGW32__)
+
+// include this header to avoid the the U(...) bing affected by macros `U()` in basic_types.h
+#include "boost/move/detail/type_traits.hpp"
 
 // Macro indicating the C++ Rest SDK product itself is being built.
 // This is to help track how many developers are directly building from source themselves.

--- a/Release/src/pplx/pplx.cpp
+++ b/Release/src/pplx/pplx.cpp
@@ -13,7 +13,7 @@
 
 #include "stdafx.h"
 
-#if !defined(_WIN32) || CPPREST_FORCE_PPLX
+#if !defined(_WIN32) || defined(__MINGW32__) || CPPREST_FORCE_PPLX
 #include "pplx/pplx.h"
 #include <atomic>
 

--- a/Release/src/pplx/pplxlinux.cpp
+++ b/Release/src/pplx/pplxlinux.cpp
@@ -15,10 +15,12 @@
 
 #include "pplx/pplx.h"
 #include "pplx/threadpool.h"
+#if !defined(__MINGW32__)
 #include "sys/syscall.h"
+#endif
 #include <thread>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #error "ERROR: This file should only be included in non-windows Build"
 #endif
 

--- a/Release/src/pplx/threadpool.cpp
+++ b/Release/src/pplx/threadpool.cpp
@@ -87,7 +87,7 @@ private:
     boost::asio::io_service::work m_work;
 };
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 struct shared_threadpool
 {
 #if defined(_MSC_VER) && _MSC_VER < 1900

--- a/Release/tests/common/TestRunner/test_runner.cpp
+++ b/Release/tests/common/TestRunner/test_runner.cpp
@@ -505,12 +505,14 @@ int main(int argc, char* argv[])
     Windows::Foundation::Initialize(RO_INIT_MULTITHREADED);
 #elif defined(_WIN32)
     // Add standard error as output as well.
+#if !defined(__MINGW32__)
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_WNDW | _CRTDBG_MODE_DEBUG);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_WNDW | _CRTDBG_MODE_DEBUG);
     _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
     _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+#endif // !defined(__MINGW32__)
 
     // The test runner built with WinRT support might be used on a pre Win8 machine.
     // Obviously in that case WinRT test cases can't run, but non WinRT ones should be
@@ -567,7 +569,7 @@ int main(int argc, char* argv[])
     {
         listOption = true;
     }
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
     if (UnitTest::GlobalSettings::Has("detectleaks"))
     {
         _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);

--- a/Release/tests/common/UnitTestpp/src/CheckMacros.h
+++ b/Release/tests/common/UnitTestpp/src/CheckMacros.h
@@ -94,7 +94,7 @@
 #error UnitTest++ redefines VERIFY_IS_NULL
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 #define VERIFY_IS_TRUE(expression, ...) CHECK_EQUAL(true, expression, __VA_ARGS__)
 #define VERIFY_IS_FALSE(expression, ...) CHECK_EQUAL(false, expression, __VA_ARGS__)
 #define VERIFY_ARE_NOT_EQUAL(expected, actual, ...) CHECK_NOT_EQUAL(expected, actual, __VA_ARGS__)
@@ -118,7 +118,7 @@
             UnitTest::TestDetails(*UnitTest::CurrentTest::Details(), __LINE__), #value);                               \
     UNITTEST_MULTILINE_MACRO_END
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 
 #define CHECK_EQUAL(expected, actual, ...)                                                                             \
     do                                                                                                                 \

--- a/Release/tests/common/UnitTestpp/src/HelperMacros.h
+++ b/Release/tests/common/UnitTestpp/src/HelperMacros.h
@@ -48,8 +48,13 @@
 #endif
 
 #ifdef UNITTEST_WIN32_DLL
+#if defined(__MINGW32__)
+#define UNITTEST_IMPORT
+#define UNITTEST_EXPORT
+#else
 #define UNITTEST_IMPORT __declspec(dllimport)
 #define UNITTEST_EXPORT __declspec(dllexport)
+#endif
 
 #ifdef UNITTEST_DLL_EXPORT
 #define UNITTEST_LINKAGE UNITTEST_EXPORT

--- a/Release/tests/common/UnitTestpp/src/TestMacros.h
+++ b/Release/tests/common/UnitTestpp/src/TestMacros.h
@@ -63,7 +63,11 @@
 #define CREATED_GET_TEST_LIST
 
 #ifdef _WIN32
+#if defined(__MINGW32__)
+#define _DLL_EXPORT
+#else
 #define _DLL_EXPORT __declspec(dllexport)
+#endif
 #elif __APPLE__
 #define _DLL_EXPORT __attribute__((visibility("default")))
 #else
@@ -93,7 +97,7 @@ extern "C" _DLL_EXPORT TestList& __cdecl GetTestList();
     }                                                                                                                  \
     namespace Suite##Name
 
-#ifdef _WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 #define TEST_EX(Name, List, ...)                                                                                       \
     class Test##Name : public UnitTest::Test                                                                           \
     {                                                                                                                  \
@@ -124,13 +128,13 @@ extern "C" _DLL_EXPORT TestList& __cdecl GetTestList();
     void Test##Name::RunImpl() const
 #endif
 
-#ifdef _WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 #define TEST(Name, ...) TEST_EX(Name, UnitTest::GetTestList(), __VA_ARGS__)
 #else
 #define TEST(Name, ...) TEST_EX(Name, UnitTest::GetTestList(), ##__VA_ARGS__)
 #endif
 
-#ifdef _WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 #define TEST_FIXTURE_EX(Fixture, Name, List, ...)                                                                      \
     class Fixture##Name##Helper : public Fixture                                                                       \
     {                                                                                                                  \
@@ -242,7 +246,7 @@ extern "C" _DLL_EXPORT TestList& __cdecl GetTestList();
     void Fixture##Name##Helper::RunImpl()
 #endif
 
-#ifdef _WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 #define TEST_FIXTURE(Fixture, Name, ...) TEST_FIXTURE_EX(Fixture, Name, UnitTest::GetTestList(), __VA_ARGS__)
 #else
 #define TEST_FIXTURE(Fixture, Name, ...) TEST_FIXTURE_EX(Fixture, Name, UnitTest::GetTestList(), ##__VA_ARGS__)

--- a/Release/tests/common/UnitTestpp/src/TestRunner.cpp
+++ b/Release/tests/common/UnitTestpp/src/TestRunner.cpp
@@ -36,7 +36,9 @@
 #include "TestMacros.h"
 
 #if _MSC_VER == 1600
+#if !defined(__MINGW32__)
 #include <agents.h>
+#endif
 #include <functional>
 #else
 #include <future>

--- a/Release/tests/common/utilities/include/common_utilities_public.h
+++ b/Release/tests/common/utilities/include/common_utilities_public.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__cplusplus_winrt)
+#if (!defined(_WIN32) && !defined(__cplusplus_winrt)) || defined(__MINGW32__)
 #define TEST_UTILITY_API
-#endif // !_WIN32 && !__cplusplus_winrt
+#endif // !_WIN32 && !__cplusplus_winrt || defined(__MINGW32__)
 
 #ifndef TEST_UTILITY_API
 #ifdef COMMONUTILITIES_EXPORTS

--- a/Release/tests/functional/http/client/CMakeLists.txt
+++ b/Release/tests/functional/http/client/CMakeLists.txt
@@ -35,7 +35,11 @@ endif()
 
 configure_pch(httpclient_test stdafx.h stdafx.cpp)
 
-if(NOT WIN32)
+if((NOT WIN32) OR MINGW)
   cpprest_find_boost()
   target_link_libraries(httpclient_test PRIVATE cpprestsdk_boost_internal)
+endif()
+
+if(MINGW)
+  target_link_libraries(httpclient_test PRIVATE ws2_32 wsock32)
 endif()

--- a/Release/tests/functional/http/client/authentication_tests.cpp
+++ b/Release/tests/functional/http/client/authentication_tests.cpp
@@ -477,7 +477,7 @@ SUITE(authentication_tests)
     }
 #endif // __cplusplus_winrt
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #if !defined(__cplusplus_winrt)
     TEST_FIXTURE(server_properties, set_user_options, "Requires", "Server;UserName;Password")
     {

--- a/Release/tests/functional/http/client/request_stream_tests.cpp
+++ b/Release/tests/functional/http/client/request_stream_tests.cpp
@@ -31,7 +31,12 @@ namespace http
 {
 namespace client
 {
+
+#if defined(__MINGW32__)
+std::string get_full_name(const utility::string_t& name)
+#else
 utility::string_t get_full_name(const utility::string_t& name)
+#endif // __MINGW32__
 {
 #if defined(__cplusplus_winrt)
     // On WinRT, we must compensate for the fact that we will be accessing files in the
@@ -41,7 +46,11 @@ utility::string_t get_full_name(const utility::string_t& name)
                     .get();
     return file->Path->Data();
 #else
+#if defined(__MINGW32__)
+    return utility::conversions::to_utf8string(name);
+#else
     return name;
+#endif // __MINGW32__
 #endif
 }
 

--- a/Release/tests/functional/http/listener/CMakeLists.txt
+++ b/Release/tests/functional/http/listener/CMakeLists.txt
@@ -23,4 +23,8 @@ if(NOT WINDOWS_STORE AND NOT WINDOWS_PHONE)
   endif()
 
   configure_pch(httplistener_test stdafx.h stdafx.cpp)
+
+  if(MINGW)
+    target_link_libraries(httplistener_test PRIVATE ws2_32 wsock32)
+  endif()
 endif()

--- a/Release/tests/functional/http/listener/connections_and_errors.cpp
+++ b/Release/tests/functional/http/listener/connections_and_errors.cpp
@@ -18,7 +18,7 @@
 #include <cpprest/http_client.h>
 
 // For single_core test case.
-#if defined(_WIN32) && _MSC_VER < 1900
+#if defined(_WIN32) && _MSC_VER < 1900 && !defined(__MINGW32__)
 #include <concrt.h>
 #endif
 
@@ -149,7 +149,7 @@ SUITE(connections_and_errors)
         listener.close().wait();
     }
 
-#if defined(_WIN32) && _MSC_VER < 1900
+#if defined(_WIN32) && _MSC_VER < 1900 && !defined(__MINGW32__)
     TEST_FIXTURE(uri_address, single_core_request)
     {
         // Fake having a scheduler with only 1 core.

--- a/Release/tests/functional/http/listener/response_stream_tests.cpp
+++ b/Release/tests/functional/http/listener/response_stream_tests.cpp
@@ -39,7 +39,11 @@ SUITE(response_stream_tests)
     // Used to prepare data for read tests
     void fill_file(const utility::string_t& name, size_t repetitions = 1)
     {
+#if defined(__MINGW32__)
+        std::fstream stream(utility::conversions::to_utf8string(name), std::ios_base::out | std::ios_base::trunc);
+#else
         std::fstream stream(name, std::ios_base::out | std::ios_base::trunc);
+#endif
 
         for (size_t i = 0; i < repetitions; i++)
             stream << "abcdefghijklmnopqrstuvwxyz";

--- a/Release/tests/functional/http/utilities/CMakeLists.txt
+++ b/Release/tests/functional/http/utilities/CMakeLists.txt
@@ -15,6 +15,12 @@ target_link_libraries(httptest_utilities PUBLIC
   unittestpp
   common_utilities
 )
+if(MINGW)
+  target_link_libraries(httptest_utilities PRIVATE
+    ws2_32
+    wsock32
+  )
+endif()
 if(WINDOWS_STORE)
   target_compile_options(httptest_utilities PRIVATE /DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP)
 endif()

--- a/Release/tests/functional/http/utilities/include/http_test_utilities_public.h
+++ b/Release/tests/functional/http/utilities/include/http_test_utilities_public.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__cplusplus_winrt)
+#if (!defined(_WIN32) && !defined(__cplusplus_winrt)) || defined(__MINGW32__)
 #define TEST_UTILITY_API
-#endif // !_WIN32 && !__cplusplus_winrt
+#endif // !_WIN32 && !__cplusplus_winrt || defined(__MINGW32__)
 
 #ifndef TEST_UTILITY_API
 #ifdef HTTPTESTUTILITY_EXPORTS

--- a/Release/tests/functional/http/utilities/test_http_client.cpp
+++ b/Release/tests/functional/http/utilities/test_http_client.cpp
@@ -15,7 +15,7 @@
 
 #include "cpprest/details/http_helpers.h"
 #include "cpprest/uri.h"
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <winhttp.h>
 #pragma comment(lib, "winhttp.lib")
 #pragma warning(push)
@@ -47,7 +47,7 @@ utility::string_t flatten_http_headers(const std::map<utility::string_t, utility
     return flattened_headers;
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 
 // Helper function to query for the size of header values.
 static void query_header_length(HINTERNET request_handle, DWORD header, DWORD& length)
@@ -403,7 +403,7 @@ public:
                           size_t data_length)
     {
         auto localHeaders = headers;
-        localHeaders["User-Agent"] = "test_http_client";
+        localHeaders[_XPLATSTR("User-Agent")] = _XPLATSTR("test_http_client");
         web::http::http_request request;
         request.set_method(method);
         request.set_request_uri(web::http::uri_builder(m_uri).append_path(path).to_uri());
@@ -416,7 +416,7 @@ public:
             else
                 currentValue = currentValue + U(", ") + it->second;
         }
-        request.set_body(utility::string_t(reinterpret_cast<const char*>(data), data_length));
+        request.set_body(utility::string_t(reinterpret_cast<const utility::char_t*>(data), data_length));
 
         m_responses.push_back(m_client.request(request));
         return 0;

--- a/Release/tests/functional/http/utilities/test_http_server.cpp
+++ b/Release/tests/functional/http/utilities/test_http_server.cpp
@@ -10,7 +10,7 @@
  ****/
 #include "stdafx.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <http.h>
 #pragma comment(lib, "httpapi.lib")
 #pragma warning(push)
@@ -74,7 +74,7 @@ struct test_server_queue
     }
 };
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 // Helper function to parse verb from Windows HTTP Server API.
 static utility::string_t parse_verb(const HTTP_REQUEST* p_http_request)
 {

--- a/Release/tests/functional/json/CMakeLists.txt
+++ b/Release/tests/functional/json/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT WINDOWS_STORE AND NOT WINDOWS_PHONE)
 endif()
 
 add_casablanca_test(json_test SOURCES)
-if(UNIX AND NOT APPLE)
+if((UNIX OR MINGW) AND NOT APPLE)
   cpprest_find_boost()
   target_link_libraries(json_test PRIVATE cpprestsdk_boost_internal)
 endif()

--- a/Release/tests/functional/json/parsing_tests.cpp
+++ b/Release/tests/functional/json/parsing_tests.cpp
@@ -14,7 +14,7 @@
 #include <array>
 #include <iomanip>
 
-#if defined(_WIN32) || defined(__APPLE__)
+#if (defined(_WIN32) && !defined(__MINGW32__)) || defined(__APPLE__)
 #include <regex>
 #elif (defined(ANDROID) || defined(__ANDROID__))
 #else
@@ -172,7 +172,7 @@ namespace json_tests
 {
 inline bool verify_parsing_error_msg(const std::string& str)
 {
-#if defined(_WIN32) || defined(__APPLE__)
+#if (defined(_WIN32) && !defined(__MINGW32__)) || defined(__APPLE__)
     auto spattern = "^\\* Line \\d+, Column \\d+ Syntax error: .+";
     static std::regex pattern(spattern);
     return std::regex_match(str, pattern, std::regex_constants::match_flag_type::match_not_null);

--- a/Release/tests/functional/pplx/pplx_test/CMakeLists.txt
+++ b/Release/tests/functional/pplx/pplx_test/CMakeLists.txt
@@ -7,3 +7,7 @@ set(SOURCES
 add_casablanca_test(pplx_test SOURCES)
 
 configure_pch(pplx_test stdafx.h stdafx.cpp)
+
+if(MINGW)
+  target_link_libraries(pplx_test PRIVATE ws2_32 wsock32)
+endif()

--- a/Release/tests/functional/pplx/pplx_test/stdafx.h
+++ b/Release/tests/functional/pplx/pplx_test/stdafx.h
@@ -12,6 +12,10 @@
 #pragma once
 
 #ifdef _WIN32
+#if defined(__MINGW32__)
+#include <winsock2.h>
+#endif
+
 #include <Windows.h>
 #endif
 
@@ -22,7 +26,7 @@
 #include <time.h>
 #include <vector>
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "pplx/pplxconv.h"
 #else
 #include "pplx/threadpool.h"

--- a/Release/tests/functional/streams/fstreambuf_tests.cpp
+++ b/Release/tests/functional/streams/fstreambuf_tests.cpp
@@ -18,7 +18,7 @@
 using namespace Windows::Storage;
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define DEFAULT_PROT (int)std::ios_base::_Openprot
 #else
 #define DEFAULT_PROT 0
@@ -36,7 +36,11 @@ using namespace ::pplx;
 
 // Used to prepare data for read tests
 
+#if defined(__MINGW32__)
+std::string get_full_name(const utility::string_t& name);
+#else
 utility::string_t get_full_name(const utility::string_t& name);
+#endif // __MINGW32__
 
 void fill_file(const utility::string_t& name, size_t repetitions = 1);
 #ifdef _WIN32

--- a/Release/tests/functional/streams/istream_tests.cpp
+++ b/Release/tests/functional/streams/istream_tests.cpp
@@ -21,7 +21,7 @@
 using namespace Windows::Storage;
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define DEFAULT_PROT (int)std::ios_base::_Openprot
 #else
 #define DEFAULT_PROT 0
@@ -39,7 +39,11 @@ using namespace concurrency::streams;
 
 // Used to prepare data for file-stream read tests
 
+#if defined(__MINGW32__)
+std::string get_full_name(const utility::string_t& name)
+#else
 utility::string_t get_full_name(const utility::string_t& name)
+#endif // __MINGW32__
 {
 #if defined(__cplusplus_winrt)
     // On WinRT, we must compensate for the fact that we will be accessing files in the
@@ -49,7 +53,11 @@ utility::string_t get_full_name(const utility::string_t& name)
                     .get();
     return file->Path->Data();
 #else
+#if defined(__MINGW32__)
+    return utility::conversions::to_utf8string(name);
+#else
     return name;
+#endif // __MINGW32__
 #endif
 }
 
@@ -77,7 +85,7 @@ void fill_file_with_lines(const utility::string_t& name, const std::string& end,
 void fill_file_w(const utility::string_t& name, size_t repetitions = 1)
 {
     FILE* stream = nullptr;
-    _wfopen_s(&stream, get_full_name(name).c_str(), L"w");
+    _wfopen_s(&stream, utility::conversions::to_utf16string(get_full_name(name)).c_str(), L"w");
     if (stream == nullptr)
     {
         VERIFY_IS_TRUE(false, "FILE pointer is null");

--- a/Release/tests/functional/streams/stdstream_tests.cpp
+++ b/Release/tests/functional/streams/stdstream_tests.cpp
@@ -22,7 +22,7 @@
 using namespace Windows::Storage;
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define DEFAULT_PROT (int)std::ios_base::_Openprot
 #else
 #define DEFAULT_PROT 0
@@ -37,7 +37,11 @@ namespace streams
 using namespace ::pplx;
 using namespace utility;
 
+#if defined(__MINGW32__)
+std::string get_full_name(const utility::string_t& name);
+#else
 utility::string_t get_full_name(const utility::string_t& name);
+#endif // __MINGW32__
 
 template<typename CharType>
 void extract_test(std::basic_istream<CharType>& stream, std::basic_string<CharType> expected)

--- a/Release/tests/functional/utils/CMakeLists.txt
+++ b/Release/tests/functional/utils/CMakeLists.txt
@@ -14,3 +14,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 configure_pch(utils_test stdafx.h stdafx.cpp)
+
+if(MINGW)
+  target_link_libraries(utils_test PRIVATE ws2_32 wsock32)
+endif()

--- a/Release/tests/functional/websockets/CMakeLists.txt
+++ b/Release/tests/functional/websockets/CMakeLists.txt
@@ -16,6 +16,10 @@ if (NOT CPPREST_EXCLUDE_WEBSOCKETS)
       cpprestsdk_websocketpp_internal
   )
 
+  if(MINGW)
+    target_link_libraries(websockettest_utilities PRIVATE ws2_32 wsock32)
+  endif()
+
   # websocketsclient_test
   set(SOURCES
     client/authentication_tests.cpp
@@ -32,4 +36,8 @@ if (NOT CPPREST_EXCLUDE_WEBSOCKETS)
     target_link_libraries(websocketsclient_test PRIVATE websockettest_utilities)
   endif()
   target_include_directories(websocketsclient_test PRIVATE utilities)
+
+  if(MINGW)
+    target_link_libraries(websocketsclient_test PRIVATE ws2_32 wsock32)
+  endif()
 endif()

--- a/Release/tests/functional/websockets/client/send_msg_tests.cpp
+++ b/Release/tests/functional/websockets/client/send_msg_tests.cpp
@@ -13,6 +13,8 @@
 
 #include "stdafx.h"
 
+#include <cstdlib>
+
 #if defined(__cplusplus_winrt) || !defined(_M_ARM)
 
 using namespace concurrency;
@@ -37,7 +39,11 @@ namespace client
 {
 SUITE(send_msg_tests)
 {
+#if defined(__MINGW32__)
+    std::string get_full_name(const utility::string_t& name)
+#else
     utility::string_t get_full_name(const utility::string_t& name)
+#endif // __MINGW32__
     {
 #if defined(__cplusplus_winrt)
         // On WinRT, we must compensate for the fact that we will be accessing files in the
@@ -48,7 +54,11 @@ SUITE(send_msg_tests)
                 .get();
         return file->Path->Data();
 #else
+#if defined(__MINGW32__)
+        return utility::conversions::to_utf8string(name);
+#else
         return name;
+#endif // __MINGW32__
 #endif
     }
 

--- a/Release/tests/functional/websockets/utilities/test_websocket_server.cpp
+++ b/Release/tests/functional/websockets/utilities/test_websocket_server.cpp
@@ -22,7 +22,7 @@
 #pragma warning(disable : 4100 4127 4996 4512 4701 4267 4067 4005)
 #define _WEBSOCKETPP_CPP11_STL_
 #define _WEBSOCKETPP_CONSTEXPR_TOKEN_
-#if _MSC_VER < 1900
+#if (_MSC_VER < 1900) && !defined(__MINGW32__)
 #define _WEBSOCKETPP_NOEXCEPT_TOKEN_
 #endif
 #endif /* _WIN32 */
@@ -32,8 +32,11 @@
 #pragma clang diagnostic ignored "-Winfinite-recursion"
 #endif
 
+#pragma push_macro("U")
+#undef U
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/server.hpp>
+#pragma pop_macro("U")
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/Release/tests/functional/websockets/utilities/test_websocket_server.h
+++ b/Release/tests/functional/websockets/utilities/test_websocket_server.h
@@ -20,9 +20,17 @@
 
 #ifndef WEBSOCKET_UTILITY_API
 #ifdef WEBSOCKETTESTUTILITY_EXPORTS
+#if defined(__MINGW32__)
+#define WEBSOCKET_UTILITY_API
+#else
 #define WEBSOCKET_UTILITY_API __declspec(dllexport)
+#endif // defined(__MINGW32__)
+#else
+#if defined(__MINGW32__)
+#define WEBSOCKET_UTILITY_API
 #else
 #define WEBSOCKET_UTILITY_API __declspec(dllimport)
+#endif // defined(__MINGW32__)
 #endif
 #endif
 


### PR DESCRIPTION
Supporting for MinGW on Windows is a long-standling feature request for the cpprestsdk project. This PR makes the codebase compilable with mingw-w64 from msys2, include main library, test cases and examples.

At the same time, this PR has minimized the changeset for the convenience of code review.

Resolves #202, #1361 and #1541.