### PR TITLE
export http_exception for non Windows builds

### DIFF
--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -187,7 +187,11 @@ public:
 /// <summary>
 /// Represents an HTTP error. This class holds an error message and an optional error code.
 /// </summary>
+#ifdef _WIN32
 class http_exception : public std::exception
+#else
+class _ASYNCRTIMP http_exception : public std::exception
+#endif
 {
 public:
     /// <summary>


### PR DESCRIPTION
If a project compiled with clang for macos links to CppRest, and the
-fvisibility=hidden compiler option is used, the http_exception is used
as std::exception. The clang compiler requires it to be exported in
order to know about the symbols.

Since the Visual Studio compiler throws warnings regarding the export of
a class that inherits from a non-exported class, std::exception in this
case, the WIN32 define check is added to omit this export.