### PR TITLE
export http_exception for non Windows builds

### DIFF
--- a/Release/include/cpprest/details/cpprest_compat.h
+++ b/Release/include/cpprest/details/cpprest_compat.h
@@ -71,12 +71,20 @@
 
 #ifdef _NO_ASYNCRTIMP
 #define _ASYNCRTIMP
+#define _ASYNCRTIMP_TYPEINFO
 #else // ^^^ _NO_ASYNCRTIMP ^^^ // vvv !_NO_ASYNCRTIMP vvv
 #ifdef _ASYNCRT_EXPORT
 #define _ASYNCRTIMP __declspec(dllexport)
 #else // ^^^ _ASYNCRT_EXPORT ^^^ // vvv !_ASYNCRT_EXPORT vvv
 #define _ASYNCRTIMP __declspec(dllimport)
 #endif // _ASYNCRT_EXPORT
+
+#if defined(_WIN32)
+#define _ASYNCRTIMP_TYPEINFO
+#else // ^^^ _WIN32 ^^^ // vvv !_WIN32 vvv
+#define _ASYNCRTIMP_TYPEINFO __attribute__((visibility("default")))
+#endif // _WIN32
+
 #endif // _NO_ASYNCRTIMP
 
 #ifdef CASABLANCA_DEPRECATION_NO_WARNINGS

--- a/Release/include/cpprest/http_msg.h
+++ b/Release/include/cpprest/http_msg.h
@@ -187,7 +187,7 @@ public:
 /// <summary>
 /// Represents an HTTP error. This class holds an error message and an optional error code.
 /// </summary>
-class http_exception : public std::exception
+class _ASYNCRTIMP_TYPEINFO http_exception : public std::exception
 {
 public:
     /// <summary>


### PR DESCRIPTION
If a project compiled with clang for macos links to CppRest, and the
-fvisibility=hidden compiler option is used, the http_exception is used
as std::exception. The clang compiler requires it to be exported in
order to know about the symbols.

Since the Visual Studio compiler throws warnings regarding the export of
a class that inherits from a non-exported class, std::exception in this
case, the WIN32 define check is added to omit this export.