### PR TITLE
disable-socket-send-buffer option added

### DIFF
--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -97,6 +97,7 @@ public:
         : m_guarantee_order(false)
         , m_timeout(std::chrono::seconds(30))
         , m_chunksize(0)
+        , m_socket_send_buffer_disabled(false)
         , m_request_compressed(false)
 #if !defined(__cplusplus_winrt)
         , m_validate_certificates(true)
@@ -206,6 +207,19 @@ public:
     void set_timeout(const T& timeout)
     {
         m_timeout = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
+    }
+
+    /// <summary>
+    /// Returns true if the socket send buffer is disabled (SO_SNDBUF == 0 bytes size)
+    /// </summary>
+    /// <returns>True if disabled</returns>
+    bool is_socket_send_buffer_disabled() const { return m_socket_send_buffer_disabled; }
+    /// <summary>
+    /// Disables the sockets send buffer (SO_SNDBUF = 0)
+    /// </summary>
+    void disable_socket_send_buffer()
+    { 
+      m_socket_send_buffer_disabled = true;
     }
 
     /// <summary>
@@ -409,6 +423,7 @@ private:
 
     std::chrono::microseconds m_timeout;
     size_t m_chunksize;
+    bool m_socket_send_buffer_disabled;
     bool m_request_compressed;
 
 #if !defined(__cplusplus_winrt)


### PR DESCRIPTION
This PR adds an option to disable the underlying sockets send-buffer by setting SO_SNDBUF to zero.

During sending requests with larger bodies we encountered, especially on low bandwidth connections, that after the progress was set to 100% theire were still outgoing data to process. So visually, by following the progress, sending the data was done but technically the data was just pumped into the send-buffer of the socket and sits theire to wait for transmission.
This leads to a significant gap on low bandwidth connections between signaling 100% progress and finishing the task.
At 64 kbps and a one MB file this can be up to 90 seconds.
The same applies for connections suffering on a large error rate resulting in many retransmissions. The data was buffered just fine quick but it took a significant long time for finally closing the task.
On higher bandwidth or errorless connections the buffering take a minor part. 

This way we decide to send the data unbuffered. So the write-handler will ever been called if the data was successfully send by the socket and not if the data was just putted into the buffer. Regardless the network bandwidth or error-rate the task was finished right after the last chunk of data was send.

Thats maybe a worthwhile addition for people transferring larger data chunks and want to rely on a accurate progress and task completion state.