### PR TITLE
Use <boost/bind/bind.hpp> rather than <boost/bind.hpp> to avoid pragma message

### DIFF
--- a/Release/src/http/client/http_client_asio.cpp
+++ b/Release/src/http/client/http_client_asio.cpp
@@ -30,7 +30,7 @@
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/ssl/error.hpp>
 #include <boost/asio/steady_timer.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
"The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated."

No code change is necessary since those placeholders are not used, only the `boost::asio::placeholders::` ones are.