### PR TITLE
Fix likely typo in SafeInt3.hpp, that results in error with clang 15

### DIFF
--- a/Release/include/cpprest/details/SafeInt3.hpp
+++ b/Release/include/cpprest/details/SafeInt3.hpp
@@ -1574,7 +1574,7 @@ public:
     }
 
     template<typename E>
-    static void CastThrow(bool b, T& t) SAFEINT_CPP_THROW
+    static void CastThrow(T t, bool& b) SAFEINT_CPP_THROW
     {
         b = !!t;
     }


### PR DESCRIPTION
Please double check before merge.
Prior to this, it resulted in following error while trying to build with the Emscripten toolchain.

```
[  1%] Building CXX object Release/src/CMakeFiles/cpprest.dir/http/client/http_client.cpp.o
In file included from /cpprestsdk/Release/src/http/client/http_client.cpp:16:
In file included from /cpprestsdk/Release/src/pch/stdafx.h:73:
In file included from /cpprestsdk/Release/include/cpprest/details/basic_types.h:31:
/cpprestsdk/Release/include/cpprest/details/SafeInt3.hpp:1577:32: error: parameter 'b' set but not used [-Werror,-Wunused-but-set-parameter]
    static void CastThrow(bool b, T& t) SAFEINT_CPP_THROW
```