### PR TITLE
workaround clang 14 __has_declspec_attribute restriction

### DIFF
--- a/Release/include/cpprest/details/cpprest_compat.h
+++ b/Release/include/cpprest/details/cpprest_compat.h
@@ -29,7 +29,7 @@
 #else // ^^^ _WIN32 ^^^ // vvv !_WIN32 vvv
 
 #define __declspec(x) __attribute__((x))
-#define dllimport
+#define dllimport   x
 #define novtable /* no novtable equivalent */
 #define __assume(x)                                                                                                    \
     do                                                                                                                 \


### PR DESCRIPTION
clang 14 impose a new restriction on __has_declspec_attribute, the argument can not be empty.
https://github.com/llvm/llvm-project/issues/53269

cppresetsdk [cpprest_compat.h](https://github.com/microsoft/cpprestsdk/compare/master...liam-x:cpprestsdk:fix-issue-1710?expand=1#diff-42889c5f05ff275fe4036ca6b5be477e7869ce5a1a74094ba0b2f92a318b4e9e) translate dllimport to empty which cause compilation failure on clang 14.

wordaround by translate dllimport to an unrelated identifier to fix #1710 .
