### PR TITLE
Fix the windows pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,24 +3,24 @@
 jobs:
   - template: azure-devops/build-windows.yml
     parameters:
-      name: 'Windows_VS2019_x86'
+      name: 'Windows_VS2022_x86'
       targetPlatform: x86
       image: 'windows-latest'
+  - template: azure-devops/build-windows.yml
+    parameters:
+      name: 'Windows_VS2022_x64'
+      targetPlatform: x64
+      image: 'windows-latest'
+  - template: azure-devops/build-windows.yml
+    parameters:
+      name: 'Windows_VS2019_x86'
+      targetPlatform: x86
+      image: 'windows-2019'
   - template: azure-devops/build-windows.yml
     parameters:
       name: 'Windows_VS2019_x64'
       targetPlatform: x64
-      image: 'windows-latest'
-  - template: azure-devops/build-windows.yml
-    parameters:
-      name: 'Windows_VS2017_x86'
-      targetPlatform: x86
-      image: 'vs2017-win2016'
-  - template: azure-devops/build-windows.yml
-    parameters:
-      name: 'Windows_VS2017_x64'
-      targetPlatform: x64
-      image: 'vs2017-win2016'
+      image: 'windows-2019'
   - job: Windows_VS2019_UWP
     pool:
       vmImage: 'windows-latest'


### PR DESCRIPTION
This removes old versions of windows and VS pipelines that are no longer provided as azure hosted images. At some point I should add them back but it's better to have 2019 and 2022 CI than no CI. Also updates the vcpkg submodule which was woefully out of date.