### PR TITLE
Fix overflow exception when serializing

### DIFF
--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -502,7 +502,7 @@ inline size_t count_utf16_to_utf8(const utf16string& w)
                 throw std::range_error("UTF-16 string is missing low surrogate");
             }
 
-            const auto lowSurrogate = srcData[index];
+            const auto lowSurrogate = static_cast<int>(srcData[index]);
             if (lowSurrogate < L_SURROGATE_START || lowSurrogate > L_SURROGATE_END)
             {
                 throw std::range_error("UTF-16 string has invalid low surrogate");


### PR DESCRIPTION
When the MSB of the initial wchar_t is set, the lowSurrogate would be inferred to be "unsigned".
The if statement would be triggered, and the exception "UTF-16 string has invalid low surrogate" would be thrown.

This needs to be fixed by making the type "signed" and then comparing it to the integer values of the specified constants.