### PR TITLE
Fix some UBs and memory leaks

### DIFF
--- a/Release/src/http/client/http_client_winhttp.cpp
+++ b/Release/src/http/client/http_client_winhttp.cpp
@@ -294,6 +294,7 @@ public:
             , m_started(false)
             , m_done(false)
             , m_chunked(false)
+            , m_chunk_bytes(0)
         {
         }
 
@@ -679,6 +680,7 @@ private:
     winhttp_request_context(const std::shared_ptr<_http_client_communicator>& client, const http_request& request)
         : request_context(client, request)
         , m_request_handle(nullptr)
+        , m_request_handle_context(nullptr)
         , m_proxy_authentication_tried(false)
         , m_server_authentication_tried(false)
         , m_remaining_redirects(0)

--- a/Release/src/uri/uri.cpp
+++ b/Release/src/uri/uri.cpp
@@ -547,7 +547,7 @@ uri::uri(const details::uri_components& components) : m_components(components)
 {
     m_uri = m_components.join();
 
-    if (!uri::validate(m_uri.c_str()))
+    if (!uri::validate(m_uri))
     {
         throw uri_exception("provided uri is invalid: " + utility::conversions::to_utf8string(m_uri));
     }

--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -117,6 +117,7 @@ scoped_c_thread_locale::xplat_locale scoped_c_thread_locale::c_locale()
         *clocale = _create_locale(LC_ALL, "C");
         if (clocale == nullptr || *clocale == nullptr)
         {
+            delete clocale;
             throw std::runtime_error("Unable to create 'C' locale.");
         }
         auto deleter = [](scoped_c_thread_locale::xplat_locale* clocale) {
@@ -127,6 +128,7 @@ scoped_c_thread_locale::xplat_locale scoped_c_thread_locale::c_locale()
         *clocale = newlocale(LC_ALL_MASK, "C", nullptr);
         if (clocale == nullptr || *clocale == nullptr)
         {
+            delete clocale;
             throw std::runtime_error("Unable to create 'C' locale.");
         }
         auto deleter = [](scoped_c_thread_locale::xplat_locale *clocale)


### PR DESCRIPTION
* Do not leak `clocale` on `_create_locale` failed.
* Add missed class member initializers to prevent UB on access to them.
* Do not perform `string` -> `char*` -> `string` casts, use `string` directly.

Found by PVS-Studio https://pvs-studio.com/en/