### PR TITLE
Fix bug when offset is not applied in seekof(..., std::ios_base::end, ...)

### DIFF
--- a/Release/include/cpprest/details/fileio.h
+++ b/Release/include/cpprest/details/fileio.h
@@ -202,7 +202,7 @@ extern "C"
     /// Adjust the internal buffers and pointers when the application seeks to a new read location in the stream.
     /// </summary>
     /// <param name="info">The file info record of the file</param>
-    /// <param name="pos">The new position (offset from the start) in the file stream</param>
+    /// <param name="pos">The new position (offset from the end) in the file stream</param>
     /// <returns><c>true</c> if the request was initiated</returns>
     _ASYNCRTIMP size_t __cdecl _seekrdtoend_fsb(_In_ concurrency::streams::details::_file_info* info,
                                                 int64_t offset,

--- a/Release/src/streams/fileio_win32.cpp
+++ b/Release/src/streams/fileio_win32.cpp
@@ -916,7 +916,15 @@ size_t __cdecl _seekrdtoend_fsb(_In_ streams::details::_file_info* info, int64_t
     }
     else
     {
-        fInfo->m_rdpos = static_cast<size_t>(filesize.QuadPart) / char_size;
+        int64_t offset_from_end = offset * static_cast<int64_t>(char_size);
+        if (offset_from_end > 0 ||
+            static_cast<size_t>(-offset_from_end) > static_cast<size_t>(filesize.QuadPart))
+        {
+            // Overflow or underflow.
+            return static_cast<size_t>(-1);
+        }
+
+        fInfo->m_rdpos = static_cast<size_t>(filesize.QuadPart + offset_from_end) / char_size;
     }
 #else
     auto newpos = SetFilePointer(fInfo->m_handle, (LONG)(offset * char_size), nullptr, FILE_END);

--- a/Release/tests/functional/streams/fstreambuf_tests.cpp
+++ b/Release/tests/functional/streams/fstreambuf_tests.cpp
@@ -788,6 +788,28 @@ SUITE(file_buffer_tests)
         VERIFY_ARE_EQUAL(30 * 26, pos);
     }
 
+    TEST(SeekEnd2)
+    {
+        utility::string_t fname = U("SeekEnd2.txt");
+        fill_file(fname, 30);
+
+        // In order to get the implementation to buffer reads, we have to open the file
+        // with protection against sharing.
+        auto stream = OPEN_R<char>(fname).get();
+
+        auto underflow_pos = stream.seekoff(-30 * 26 - 1, std::ios_base::end, std::ios_base::in);
+
+        VERIFY_ARE_EQUAL(-1, underflow_pos);
+
+        auto overflow_pos = stream.seekoff(1, std::ios_base::end, std::ios_base::in);
+
+        VERIFY_ARE_EQUAL(-1, overflow_pos);
+
+        auto pos = stream.seekoff(-2, std::ios_base::end, std::ios_base::in);
+
+        VERIFY_ARE_EQUAL(30 * 26 - 2, pos);
+    }
+
     TEST(IsEOFTest)
     {
         utility::string_t fname = U("IsEOFTest.txt");


### PR DESCRIPTION
`offset` was not applied when we seek from end.