### PR TITLE
Fix printing the last day in a 400 year cycle.

### DIFF
--- a/Release/src/utilities/asyncrt_utils.cpp
+++ b/Release/src/utilities/asyncrt_utils.cpp
@@ -722,6 +722,12 @@ static compute_year_result compute_year_1601(int64_t secondsSince1601)
     secondsSince1601 -= year400 * SecondsIn400Years;
 
     int year100 = static_cast<int>(secondsSince1601 / SecondsIn100Years);
+    if (year100 == 4)
+    {
+        // this is the last day in a 400 year cycle
+        year100 = 3;
+    }
+
     secondsSince1601 -= year100 * SecondsIn100Years;
 
     int year4 = static_cast<int>(secondsSince1601 / SecondsIn4Years);

--- a/Release/tests/functional/utils/datetime.cpp
+++ b/Release/tests/functional/utils/datetime.cpp
@@ -146,6 +146,10 @@ SUITE(datetime)
 
     TEST(parsing_time_roundtrip_year_1604) { TestDateTimeRoundtrip(_XPLATSTR("1604-01-01T00:00:00Z")); }
 
+    TEST(parsing_time_roundtrip_year_2000_not_last_day) { TestDateTimeRoundtrip(_XPLATSTR("2000-12-30T00:00:00Z")); }
+
+    TEST(parsing_time_roundtrip_year_2000_last_day) { TestDateTimeRoundtrip(_XPLATSTR("2000-12-31T00:00:00Z")); }
+
     TEST(emitting_time_correct_day)
     {
         const auto test = utility::datetime() + UINT64_C(132004507640000000); // 2019-04-22T23:52:44 is a Monday


### PR DESCRIPTION
This was reported to me by "Jag S" over email trying to print 2000-12-31. The cause appears very similar to https://github.com/microsoft/cpprestsdk/pull/1550/files/198b034679cf7f962e242977b99ea5c63ad9eb03

I think this will cause a denial of service bug similar to the last day 365 one in the year 2400.