### PR TITLE
make Uri.is_host_loopback() only return true for localhost and 127.0.0.1 exactly

### DIFF
--- a/Release/include/cpprest/base_uri.h
+++ b/Release/include/cpprest/base_uri.h
@@ -296,13 +296,14 @@ public:
     /// A loopback URI is one which refers to a hostname or ip address with meaning only on the local machine.
     /// </summary>
     /// <remarks>
-    /// Examples include "localhost", or ip addresses in the loopback range (127.0.0.0/24).
+    /// Examples include "localhost", or "127.0.0.1". The only URIs for which this method returns true are "127.0.0.1", and "localhost",
+    /// all other URIs return false
     /// </remarks>
     /// <returns><c>true</c> if this URI references the local host, <c>false</c> otherwise.</returns>
     bool is_host_loopback() const
     {
         return !is_empty() &&
-               ((host() == _XPLATSTR("localhost")) || (host().size() > 4 && host().substr(0, 4) == _XPLATSTR("127.")));
+               ((host() == _XPLATSTR("localhost")) || (host() == _XPLATSTR("127.0.0.1")));
     }
 
     /// <summary>

--- a/Release/tests/functional/uri/constructor_tests.cpp
+++ b/Release/tests/functional/uri/constructor_tests.cpp
@@ -24,6 +24,11 @@ namespace uri_tests
 {
 SUITE(constructor_tests)
 {
+    TEST(not_really_a_loopback_uri)
+    {
+        uri u(uri::encode_uri(U("https://127.evil.com")));
+        VERIFY_IS_FALSE(u.is_host_loopback());
+    }
     TEST(parsing_constructor_char)
     {
         uri u(uri::encode_uri(U("net.tcp://steve:@testname.com:81/bleh%?qstring#goo")));

--- a/Release/tests/functional/uri/diagnostic_tests.cpp
+++ b/Release/tests/functional/uri/diagnostic_tests.cpp
@@ -82,7 +82,7 @@ SUITE(diagnostic_tests)
         VERIFY_IS_FALSE(uri(U("http://bleh/?qstring")).is_host_loopback());
         VERIFY_IS_FALSE(uri(U("http://+*/?qstring")).is_host_loopback());
         VERIFY_IS_TRUE(uri(U("http://127.0.0.1/")).is_host_loopback());
-        VERIFY_IS_TRUE(uri(U("http://127.155.0.1/")).is_host_loopback());
+        VERIFY_IS_FALSE(uri(U("http://127.155.0.1/")).is_host_loopback());
         VERIFY_IS_FALSE(uri(U("http://128.0.0.1/")).is_host_loopback());
     }
 


### PR DESCRIPTION
This makes it impossible to find a URI that cpprestsdk says is loopback and the OS doesn't (unless your resolver settings are very misconfigured. This mostly mirrors what .net does.