### PR TITLE
Add virtual destructor to scheduler_interface struct in pplxinterface.h

### DIFF
--- a/Release/include/pplx/pplxinterface.h
+++ b/Release/include/pplx/pplxinterface.h
@@ -51,6 +51,7 @@ typedef void(_pplx_cdecl* TaskProc_t)(void*);
 struct __declspec(novtable) scheduler_interface
 {
     virtual void schedule(TaskProc_t, _In_ void*) = 0;
+    virtual ~scheduler_interface() = default;
 };
 
 /// <summary>


### PR DESCRIPTION
Is any reason to not add here virtual destructor? I found this using [-Wnon-virtual-dtor] during compilation.