### PR TITLE
Fix memory leak in zero_memory_deleter on non-Windows platforms

### DIFF
--- a/Release/src/utilities/web_utilities.cpp
+++ b/Release/src/utilities/web_utilities.cpp
@@ -151,8 +151,8 @@ void zero_memory_deleter::operator()(::utility::string_t* data) const
     (void)data;
 #ifdef _WIN32
     SecureZeroMemory(&(*data)[0], data->size() * sizeof(::utility::string_t::value_type));
-    delete data;
 #endif
+    delete data;
 }
 } // namespace details
 


### PR DESCRIPTION
Move delete data outside _WIN32 macro to prevent memory leaks on non-Windows platforms.