### PR TITLE
Clearing the m_listeners map when it becomes empty

### DIFF
--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -167,6 +167,7 @@ public:
 
     void add_listener(const std::string& path, http_listener_impl* listener);
     void remove_listener(const std::string& path, http_listener_impl* listener);
+    bool is_empty_listeners() { return m_listeners.empty(); }
 
     void internal_erase_connection(asio_server_connection*);
 
@@ -1392,6 +1393,10 @@ pplx::task<void> http_linux_server::unregister_listener(http_listener_impl* list
         }
 
         itr->second->remove_listener(path, listener);
+        if (itr->second->is_empty_listeners())
+        {
+           m_listeners.erase(hostport);
+        }
     }
 
     // Second remove the listener form listener collection


### PR DESCRIPTION
_http_linux_server_ has a map _std::map<std::string, std::unique_ptr<hostport_listener>, iequal_to> m_listeners_, where new _hostport_listener_ are added with the _host+port_ key in the _pplx::task<void> http_server_api::register_listener()_ function. But there is no deletion from this map in the _pplx::task<void> http_linux_server::unregister_listener()_ function. Therefore, until _http_linux_server_ is deleted(that is, we will not close all open listener) the map will contain an _hostport_listener_ that has already been created.