### PR TITLE
[PPLX] Fixed bug in pplx::task_options(cancellation_token, task_continuation_context) constructor

### DIFF
--- a/Release/include/pplx/pplxtasks.h
+++ b/Release/include/pplx/pplxtasks.h
@@ -1270,7 +1270,7 @@ public:
         : _M_Scheduler(get_ambient_scheduler())
         , _M_CancellationToken(_Token)
         , _M_ContinuationContext(_ContinuationContext)
-        , _M_HasCancellationToken(false)
+        , _M_HasCancellationToken(true)
         , _M_HasScheduler(false)
     {
     }


### PR DESCRIPTION
Fixed bug in pplx::task_options(cancellation_token, task_continuation_context) constructor - should set _M_HasCancellationToken to true. Bug was introduced in PPL in VS2013 and fixed in VS2015 but survives in PPLX. Note - it is one of 4 .ctors, bug is only in this one