### PR TITLE
Fix errors about implicit "this" capture in C++20 mode

### DIFF
--- a/Release/include/cpprest/details/basic_types.h
+++ b/Release/include/cpprest/details/basic_types.h
@@ -129,3 +129,18 @@ typedef std::basic_istringstream<utf16char> utf16istringstream;
 #endif
 #endif
 #endif
+
+// This is not really a basic type, but define this macro in this header
+// because it's included by all the other ones and this macro needs to be
+// available in several places.
+#if defined(_MSVC_LANG)
+#define CPPREST_CHECK_CXX_STD(ver) (_MSVC_LANG >= (ver))
+#else
+#define CPPREST_CHECK_CXX_STD(ver) (__cplusplus >= (ver))
+#endif
+
+#if CPPREST_CHECK_CXX_STD(202002L)
+#define CPPREST_CAPTURE_THIS ,this
+#else
+#define CPPREST_CAPTURE_THIS
+#endif

--- a/Release/include/cpprest/filestream.h
+++ b/Release/include/cpprest/filestream.h
@@ -239,7 +239,7 @@ protected:
             // Neither heads are open. Close the underlying device
 
             // We need to flush all writes if the file was opened for writing.
-            return flush_internal().then([=](pplx::task<void> flushTask) -> pplx::task<void> {
+            return flush_internal().then([= CPPREST_CAPTURE_THIS](pplx::task<void> flushTask) -> pplx::task<void> {
                 // swallow exception from flush
                 try
                 {
@@ -527,7 +527,7 @@ protected:
     /// reached, EOF if there is some error.</returns>
     virtual pplx::task<size_t> _getn(_Out_writes_(count) _CharType* ptr, _In_ size_t count)
     {
-        return m_readOps.enqueue_operation([=]() -> pplx::task<size_t> {
+        return m_readOps.enqueue_operation([= CPPREST_CAPTURE_THIS]() -> pplx::task<size_t> {
             if (m_info->m_atend || count == 0) return pplx::task_from_result<size_t>(0);
 
             if (_in_avail_unprot() >= count)

--- a/Release/include/pplx/pplxtasks.h
+++ b/Release/include/pplx/pplxtasks.h
@@ -2514,7 +2514,7 @@ struct _Task_impl : public _Task_impl_base
             if (_M_Continuations)
             {
                 // Scheduling cancellation with automatic inlining.
-                _ScheduleFuncWithAutoInline([=]() { _RunTaskContinuations(); }, details::_DefaultAutoInline);
+                _ScheduleFuncWithAutoInline([= CPPREST_CAPTURE_THIS]() { _RunTaskContinuations(); }, details::_DefaultAutoInline);
             }
         }
         return true;

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -420,7 +420,7 @@ private:
     will_erase_from_parent_t do_response()
     {
         auto unique_reference = this->get_reference();
-        get_request().get_response().then([=](pplx::task<http_response> r_task) {
+        get_request().get_response().then([= CPPREST_CAPTURE_THIS](pplx::task<http_response> r_task) {
             http_response response;
             try
             {
@@ -434,7 +434,7 @@ private:
             serialize_headers(response);
 
             // before sending response, the full incoming message need to be processed.
-            return get_request().content_ready().then([=](pplx::task<http_request>) {
+            return get_request().content_ready().then([= CPPREST_CAPTURE_THIS](pplx::task<http_request>) {
                 (will_deref_and_erase_t) this->async_write(&asio_server_connection::handle_headers_written, response);
             });
         });
@@ -444,7 +444,7 @@ private:
     will_erase_from_parent_t do_bad_response()
     {
         auto unique_reference = this->get_reference();
-        get_request().get_response().then([=](pplx::task<http_response> r_task) {
+        get_request().get_response().then([= CPPREST_CAPTURE_THIS](pplx::task<http_response> r_task) {
             http_response response;
             try
             {
@@ -882,7 +882,7 @@ will_deref_t asio_server_connection::handle_chunked_body(const boost::system::er
     {
         auto writebuf = requestImpl->outstream().streambuf();
         writebuf.putn_nocopy(buffer_cast<const uint8_t*>(m_request_buf.data()), toWrite)
-            .then([=](pplx::task<size_t> writeChunkTask) -> will_deref_t {
+            .then([= CPPREST_CAPTURE_THIS](pplx::task<size_t> writeChunkTask) -> will_deref_t {
                 try
                 {
                     writeChunkTask.get();
@@ -947,13 +947,13 @@ will_deref_and_erase_t asio_server_connection::async_write(WriteFunc response_fu
 {
     if (m_ssl_stream)
     {
-        boost::asio::async_write(*m_ssl_stream, m_response_buf, [=](const boost::system::error_code& ec, std::size_t) {
+        boost::asio::async_write(*m_ssl_stream, m_response_buf, [= CPPREST_CAPTURE_THIS](const boost::system::error_code& ec, std::size_t) {
             (this->*response_func_ptr)(response, ec);
         });
     }
     else
     {
-        boost::asio::async_write(*m_socket, m_response_buf, [=](const boost::system::error_code& ec, std::size_t) {
+        boost::asio::async_write(*m_socket, m_response_buf, [= CPPREST_CAPTURE_THIS](const boost::system::error_code& ec, std::size_t) {
             (this->*response_func_ptr)(response, ec);
         });
     }
@@ -1135,7 +1135,7 @@ will_deref_and_erase_t asio_server_connection::handle_write_chunked_response(con
     auto membuf = m_response_buf.prepare(ChunkSize + chunked_encoding::additional_encoding_space);
 
     readbuf.getn(buffer_cast<uint8_t*>(membuf) + chunked_encoding::data_offset, ChunkSize)
-        .then([=](pplx::task<size_t> actualSizeTask) -> will_deref_and_erase_t {
+        .then([= CPPREST_CAPTURE_THIS](pplx::task<size_t> actualSizeTask) -> will_deref_and_erase_t {
             size_t actualSize = 0;
             try
             {
@@ -1168,7 +1168,7 @@ will_deref_and_erase_t asio_server_connection::handle_write_large_response(const
             response, std::make_exception_ptr(http_exception("Response stream close early!")));
     size_t readBytes = (std::min)(ChunkSize, m_write_size - m_write);
     readbuf.getn(buffer_cast<uint8_t*>(m_response_buf.prepare(readBytes)), readBytes)
-        .then([=](pplx::task<size_t> actualSizeTask) -> will_deref_and_erase_t {
+        .then([= CPPREST_CAPTURE_THIS](pplx::task<size_t> actualSizeTask) -> will_deref_and_erase_t {
             size_t actualSize = 0;
             try
             {


### PR DESCRIPTION
Capture "this" explicitly when using C++20, while still not doing it for the earlier versions of the language as it is explicitly not allowed in C++17.