### PR TITLE
Add a socket options callback to enable setting TCP keepalive

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -57,3 +57,4 @@ René Meusel (reneme)
 
 Sony Corporation
 Gareth Sylvester-Bradley (garethsb-sony)
+Simon Lo (lo-simon)

--- a/Release/include/cpprest/http_listener.h
+++ b/Release/include/cpprest/http_listener.h
@@ -18,6 +18,7 @@
 #include <limits>
 #if !defined(_WIN32) && !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
 #include <boost/asio/ssl.hpp>
+#include <boost/asio.hpp>
 #endif
 
 #if !defined(_WIN32) || (_WIN32_WINNT >= _WIN32_WINNT_VISTA && !defined(__cplusplus_winrt)) ||                         \
@@ -53,6 +54,7 @@ public:
         , m_backlog(other.m_backlog)
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
         , m_ssl_context_callback(other.m_ssl_context_callback)
+        , m_tcp_socket_callback(other.m_tcp_socket_callback)
 #endif
     {
     }
@@ -66,6 +68,7 @@ public:
         , m_backlog(std::move(other.m_backlog))
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
         , m_ssl_context_callback(std::move(other.m_ssl_context_callback))
+        , m_tcp_socket_callback(std::move(other.m_tcp_socket_callback))
 #endif
     {
     }
@@ -82,6 +85,7 @@ public:
             m_backlog = rhs.m_backlog;
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
             m_ssl_context_callback = rhs.m_ssl_context_callback;
+            m_tcp_socket_callback = rhs.m_tcp_socket_callback;
 #endif
         }
         return *this;
@@ -99,6 +103,7 @@ public:
             m_backlog = std::move(rhs.m_backlog);
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
             m_ssl_context_callback = std::move(rhs.m_ssl_context_callback);
+            m_tcp_socket_callback = std::move(rhs.m_tcp_socket_callback);
 #endif
         }
         return *this;
@@ -149,6 +154,25 @@ public:
     {
         m_ssl_context_callback = ssl_context_callback;
     }
+
+    /// <summary>
+    /// Get the callback of tcp socket
+    /// </summary>
+    /// <returns>The function defined by the user of http_listener_config to configure a tcp socket.</returns>
+    const std::function<void(boost::asio::ip::tcp::socket&)>& get_tcp_socket_callback() const
+    {
+        return m_tcp_socket_callback;
+    }
+
+    /// <summary>
+    /// Set the callback of tcp socket
+    /// </summary>
+    /// <param name="socket_callback">The function to configure a tcp socket which will setup https
+    /// connections.</param>
+    void set_tcp_socket_callback(const std::function<void(boost::asio::ip::tcp::socket&)>& tcp_socket_callback)
+    {
+        m_tcp_socket_callback = tcp_socket_callback;
+    }
 #endif
 
 private:
@@ -156,6 +180,7 @@ private:
     int m_backlog;
 #if !defined(_WIN32) || defined(CPPREST_FORCE_HTTP_LISTENER_ASIO)
     std::function<void(boost::asio::ssl::context&)> m_ssl_context_callback;
+    std::function<void(boost::asio::ip::tcp::socket&)> m_tcp_socket_callback;
 #endif
 };
 

--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -135,6 +135,7 @@ private:
 
     bool m_is_https;
     const std::function<void(boost::asio::ssl::context&)>& m_ssl_context_callback;
+    const std::function<void(boost::asio::ip::tcp::socket&)>& m_tcp_socket_callback;
 
 public:
     hostport_listener(http_linux_server* server,
@@ -150,6 +151,7 @@ public:
         , m_p_server(server)
         , m_is_https(is_https)
         , m_ssl_context_callback(config.get_ssl_context_callback())
+        , m_tcp_socket_callback(config.get_tcp_socket_callback())
     {
         m_all_connections_complete.set();
 
@@ -596,6 +598,11 @@ void hostport_listener::on_accept(std::unique_ptr<ip::tcp::socket> socket, const
         boost::asio::ip::tcp::no_delay option(true);
         boost::system::error_code error_ignored;
         socket->set_option(option, error_ignored);
+
+        if (m_tcp_socket_callback)
+        {
+            m_tcp_socket_callback(*socket);
+        }
 
         auto conn = asio_server_connection::create(std::move(socket), m_p_server, this);
 


### PR DESCRIPTION
This callback enables the user to customise the socket options, such as adding `TCP keepalive`.  It uses a similar style to the `http_client_config` for the `http_listener_config`.

Here is an example of using the callback to set the TCP keepalive.
```
inline std::function<void(boost::asio::ip::tcp::socket&)> make_listener_tcp_socket_callback()
{
    const int keepalive = 1;
    const int idle = 5;
    const int intvl = 2;
    const int cnt = 3;

    return [&](boost::asio::ip::tcp::socket& sock)
    {
        if (0 == setsockopt(sock.native_handle(), SOL_SOCKET, SO_KEEPALIVE, (const char*)&keepalive, sizeof(keepalive)))
        {
            if (keepalive)
            {
                // set keepalive parameters
                // Note: Windows does not support setsockopt(..., TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT) use WSAIoctl(SIO_KEEPALIVE_VALS)
                // to set keepalive parameters
#ifdef _WIN32
                tcp_keepalive ka = { 1, idle*1000, intvl*1000 };
                DWORD bytes = 0;
                WSAIoctl(sock.native_handle(), SIO_KEEPALIVE_VALS, &ka, sizeof(ka), NULL, 0, &bytes, NULL, NULL);
#else
                // The time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes
                setsockopt(sock.native_handle(), IPPROTO_TCP, TCP_KEEPIDLE, (const char*)&idle, sizeof(idle));

                // The time (in seconds) between individual keepalive probes
                setsockopt(sock.native_handle(), IPPROTO_TCP, TCP_KEEPINTVL, (const char*)&intvl, sizeof(intvl));

                // The maximum number of keepalive probes TCP should send before dropping the connection
                setsockopt(sock.native_handle(), IPPROTO_TCP, TCP_KEEPCNT, (const char*)&cnt, sizeof(cnt));
#endif // _WIN32
            }
        }
        else
        {
            std::cerr << "Unable to set socket keepalive";
        }
    };
}
```