### PR TITLE
Archive C++ REST SDK Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-**The C++ REST SDK is in maintenance-only mode and we do not recommend its use in new projects.
-We will continue to fix critical security issues only.**
+#  [!WARNING] ARCHIVED: [The C++ REST SDK]
+
+This repository is no longer maintained and has been archived. 
+
+- **Support**: No further issues or pull requests will be reviewed. You are free to fork this project if you wish to continue development independently.
+- **Alternatives**: Depending on your usage scenarios, alternatives to the C++ REST SDK include [libcurl](https://github.com/curl/curl) or [Boost beast](https://github.com/boostorg/beast). 
+
 
 ## Welcome!
 


### PR DESCRIPTION
Updated README to indicate that the C++ REST SDK is archived and no longer maintained, including alternatives for users.